### PR TITLE
Feature/allow naming events table

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.2.0
+base_version=0.2.1
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -22,7 +22,7 @@ val defaultObjectMapper = ObjectMapper()
 
 class RelationalDatabaseEventStore @PublishedApi internal constructor(
     private val db: Database,
-    private val events: Events,
+    val events: Events,
     synchronousProjectors: List<EventListener>,
     private val metadataClass: Class<out EventMetadata>,
     private val objectMapper: ObjectMapper

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -22,11 +22,14 @@ val defaultObjectMapper = ObjectMapper()
 
 class RelationalDatabaseEventStore @PublishedApi internal constructor(
     private val db: Database,
-    val events: Events,
+    private val events: Events,
     synchronousProjectors: List<EventListener>,
     private val metadataClass: Class<out EventMetadata>,
     private val objectMapper: ObjectMapper
 ) : EventStore {
+
+    val eventsTable: Events
+        get() = events
 
     companion object {
         inline fun <reified T: EventMetadata> create(

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -16,8 +16,8 @@ class CommandGatewayIntegrationTest : DescribeSpec({
     val h2DbUrl = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;"
     val h2Driver = "org.h2.Driver"
     val db = Database.connect(url = h2DbUrl, driver = h2Driver)
-    val eventsTable = H2DatabaseEventStore.eventsTable()
     val eventStore = RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
+    val eventsTable = eventStore.eventsTable
     val registry = listOf(
         Configuration.from(PizzaAggregate)
     )

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -17,7 +17,7 @@ class CommandGatewayIntegrationTest : DescribeSpec({
     val h2Driver = "org.h2.Driver"
     val db = Database.connect(url = h2DbUrl, driver = h2Driver)
     val eventStore = RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
-    val eventsTable = eventStore.eventsTable
+    val eventsTable = eventStore.table
     val registry = listOf(
         Configuration.from(PizzaAggregate)
     )

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
@@ -14,8 +14,8 @@ class RelationalDatabaseEventStoreTest : DescribeSpec({
     val h2DbUrl = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;"
     val h2Driver = "org.h2.Driver"
     val db = Database.connect(url = h2DbUrl, driver = h2Driver)
-    val table = H2DatabaseEventStore.eventsTable()
     val store =  RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
+    val table = store.eventsTable
 
     beforeTest {
         transaction(db) {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
@@ -15,7 +15,7 @@ class RelationalDatabaseEventStoreTest : DescribeSpec({
     val h2Driver = "org.h2.Driver"
     val db = Database.connect(url = h2DbUrl, driver = h2Driver)
     val store =  RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
-    val table = store.eventsTable
+    val table = store.table
 
     beforeTest {
         transaction(db) {


### PR DESCRIPTION
- exposes events schema as a public field on event store, since this can be really useful
- allows passing in a table name, since we might need to eg have multiple event stores in the same DB