### PR TITLE
Remove suspended function because it makes life harder with no benefit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.2.6
+base_version=0.2.7
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
@@ -1,13 +1,11 @@
 package com.cultureamp.eventsourcing
 
-import kotlinx.coroutines.delay
-
 class CommandGateway(private val eventStore: EventStore, private val registry: List<Configuration<*, *, *, *, *, *>>) {
 
-    tailrec suspend fun dispatch(command: Command, metadata: EventMetadata, retries: Int = 5): Either<CommandError, SuccessStatus> {
+    tailrec fun dispatch(command: Command, metadata: EventMetadata, retries: Int = 5): Either<CommandError, SuccessStatus> {
         val result = createOrUpdate(command, metadata)
         return if (result is Left && result.error is RetriableError && retries > 0) {
-            delay(500L)
+            Thread.sleep(500L)
             dispatch(command, metadata, retries - 1)
         } else {
             result


### PR DESCRIPTION
Since the purpose of the delay in this function is to cover
edgecases where either a) a command projection was not up to date and we
want to wait for it to catch up, or b) we have a concurrency error due
to two threads trying to update the same aggregate at the same time,
since these are both rare events the benefit of using a coroutine is
limited, and using a suspended function here makes our lives harder
when reactors use the command-gateway and therefor need to be suspended
functions themselves, and so on.