### PR TITLE
Use proper generic type for metadata so we fail at compile time

### DIFF
--- a/src/main/kotlin/com/cultureamp/eventsourcing/Aggregate.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Aggregate.kt
@@ -112,10 +112,10 @@ interface AggregateConstructorWithProjection<CC: CreationCommand, CE: CreationEv
     }
 }
 
-internal fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent> AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.create(
+internal fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent, M : EventMetadata> AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.create(
     creationCommand: CC,
-    metadata: EventMetadata,
-    eventStore: EventStore
+    metadata: M,
+    eventStore: EventStore<M>
 ): Either<CommandError, Unit> {
     return create(creationCommand).map { domainEvent ->
         val aggregate = created(domainEvent)
@@ -132,11 +132,11 @@ internal fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: Upda
 }
 
 @Suppress("UNCHECKED_CAST")
-internal fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent> AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.update(
+internal fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent, M : EventMetadata> AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.update(
     updateCommand: UC,
-    metadata: EventMetadata,
-    events: List<Event>,
-    eventStore: EventStore
+    metadata: M,
+    events: List<Event<M>>,
+    eventStore: EventStore<M>
 ): Either<CommandError, Unit> {
     val creationEvent = events.first().domainEvent as CreationEvent
     val updateEvents = events.slice(1 until events.size).map { it.domainEvent as UpdateEvent }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitor.kt
@@ -1,7 +1,7 @@
 package com.cultureamp.eventsourcing
 
-class AsyncEventProcessorMonitor(
-    private val asyncEventProcessors: List<AsyncEventProcessor>,
+class AsyncEventProcessorMonitor<M: EventMetadata>(
+    private val asyncEventProcessors: List<AsyncEventProcessor<M>>,
     private val metrics: (Lag) -> Unit
 ) {
     fun run() {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -3,18 +3,18 @@ package com.cultureamp.eventsourcing
 import com.cultureamp.common.Action
 import kotlin.random.Random
 
-interface AsyncEventProcessor {
-    val eventSource: EventSource
+interface AsyncEventProcessor<M: EventMetadata> {
+    val eventSource: EventSource<M>
     val bookmarkStore: BookmarkStore
     val bookmarkName: String
-    val eventProcessor: EventProcessor
+    val eventProcessor: EventProcessor<M>
 }
 
-class BatchedAsyncEventProcessor(
-    override val eventSource: EventSource,
+class BatchedAsyncEventProcessor<M: EventMetadata>(
+    override val eventSource: EventSource<M>,
     override val bookmarkStore: BookmarkStore,
     override val bookmarkName: String,
-    override val eventProcessor: EventProcessor,
+    override val eventProcessor: EventProcessor<M>,
     private val batchSize: Int = 1000,
     private val startLog: (Bookmark) -> Unit = { bookmark ->
         System.out.println("Polling for events for ${bookmark.name} from sequence ${bookmark.sequence}")
@@ -24,7 +24,7 @@ class BatchedAsyncEventProcessor(
             System.out.println("Finished processing batch for ${bookmark.name}, ${count} events up to sequence ${bookmark.sequence}")
         }
     }
-) : AsyncEventProcessor {
+) : AsyncEventProcessor<M> {
 
     fun processOneBatch(): Action {
         val startBookmark = bookmarkStore.bookmarkFor(bookmarkName)

--- a/src/main/kotlin/com/cultureamp/eventsourcing/DomainEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/DomainEventProcessor.kt
@@ -2,7 +2,7 @@ package com.cultureamp.eventsourcing
 
 import java.util.*
 
-interface DomainEventProcessor<E : DomainEvent> {
+interface DomainEventProcessor<in E : DomainEvent> {
     fun process(event: E, aggregateId: UUID)
 
     companion object {
@@ -16,7 +16,7 @@ interface DomainEventProcessor<E : DomainEvent> {
     }
 }
 
-interface DomainEventProcessorWithMetadata<E : DomainEvent, M : EventMetadata> {
+interface DomainEventProcessorWithMetadata<in E : DomainEvent, in M : EventMetadata> {
     fun process(event: E, aggregateId: UUID, metadata: M, eventId: UUID)
 
     companion object {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
@@ -4,36 +4,36 @@ import com.cultureamp.common.asNestedSealedConcreteClasses
 import java.util.*
 import kotlin.reflect.KClass
 
-class EventProcessor(private val domainEventProcessors: Map<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>) {
+class EventProcessor<in M: EventMetadata> (private val domainEventProcessors: Map<KClass<DomainEvent>, (DomainEvent, UUID, M, UUID) -> Any?>) {
     val eventClasses = domainEventProcessors.keys.flatMap { it.asNestedSealedConcreteClasses() }
 
-    fun process(event: Event) {
+    fun process(event: Event<out M>) {
         domainEventProcessors.filterKeys { it.isInstance(event.domainEvent) }.values.forEach { it(event.domainEvent, event.aggregateId, event.metadata, event.id) }
     }
 
     @Suppress("UNCHECKED_CAST")
     companion object {
-        inline fun <reified E : DomainEvent> from(noinline process: (E, UUID) -> Any?): EventProcessor {
+        inline fun <reified E : DomainEvent> from(noinline process: (E, UUID) -> Any?): EventProcessor<EventMetadata> {
             return from(DomainEventProcessor.from(process))
         }
 
-        inline fun <reified E : DomainEvent, reified M : EventMetadata> from(noinline process: (E, UUID, M, UUID) -> Any?): EventProcessor {
+        inline fun <reified E : DomainEvent, reified M : EventMetadata> from(noinline process: (E, UUID, M, UUID) -> Any?): EventProcessor<M> {
             return from(DomainEventProcessorWithMetadata.from(process))
         }
 
-        inline fun <reified E : DomainEvent> from(domainEventProcessor: DomainEventProcessor<E>): EventProcessor {
+        inline fun <reified E : DomainEvent> from(domainEventProcessor: DomainEventProcessor<E>): EventProcessor<EventMetadata> {
             val ignoreMetadataHandle = { domainEvent: E, aggregateId: UUID, _: EventMetadata, _: UUID -> domainEventProcessor.process(domainEvent, aggregateId) }
             val handler = (E::class to ignoreMetadataHandle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
             return EventProcessor(mapOf(handler))
         }
 
-        inline fun <reified E : DomainEvent, reified M : EventMetadata> from(domainEventProcessor: DomainEventProcessorWithMetadata<E, M>): EventProcessor {
+        inline fun <reified E : DomainEvent, reified M : EventMetadata> from(domainEventProcessor: DomainEventProcessorWithMetadata<E, M>): EventProcessor<M> {
             val handle = { domainEvent: E, aggregateId: UUID, metadata: M, eventId: UUID -> domainEventProcessor.process(domainEvent, aggregateId, metadata, eventId) }
             val handler = (E::class to handle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
             return EventProcessor(mapOf(handler))
         }
 
-        fun compose(first: EventProcessor, second: EventProcessor): EventProcessor {
+        fun <M : EventMetadata> compose(first: EventProcessor<M>, second: EventProcessor<M>): EventProcessor<M> {
             return EventProcessor(first.domainEventProcessors + second.domainEventProcessors)
         }
     }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -3,17 +3,17 @@ package com.cultureamp.eventsourcing
 import java.util.UUID
 import kotlin.reflect.KClass
 
-interface EventSink {
-    fun sink(newEvents: List<Event>, aggregateId: UUID, aggregateType: String): Either<CommandError, Unit>
+interface EventSink<M: EventMetadata> {
+    fun sink(newEvents: List<Event<M>>, aggregateId: UUID, aggregateType: String): Either<CommandError, Unit>
 }
 
-interface EventSource {
-    fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>> = emptyList(), batchSize: Int = 100) : List<SequencedEvent>
+interface EventSource<out M: EventMetadata>  {
+    fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>> = emptyList(), batchSize: Int = 100) : List<SequencedEvent<out M>>
 
     fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
 }
 
-interface EventStore : EventSink, EventSource {
-    fun eventsFor(aggregateId: UUID): List<Event>
+interface EventStore<M: EventMetadata> : EventSink<M>, EventSource<M> {
+    fun eventsFor(aggregateId: UUID): List<Event<M>>
 }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
@@ -18,16 +18,16 @@ interface UpdateCommand : Command {
     override val aggregateId: UUID
 }
 
-data class Event(
+data class Event<M: EventMetadata> (
     val id: UUID,
     val aggregateId: UUID,
     val aggregateSequence: Long,
     val createdAt: DateTime,
-    val metadata: EventMetadata,
+    val metadata: M,
     val domainEvent: DomainEvent
 )
 
-data class SequencedEvent(val event: Event, val sequence: Long)
+data class SequencedEvent<M: EventMetadata>(val event: Event<M>, val sequence: Long)
 
 open class EventMetadata
 

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -46,8 +46,6 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import java.util.*
 
-class EmptyMetadata() : EventMetadata()
-
 class CommandGatewayIntegrationTest : DescribeSpec({
     val h2DbUrl = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;"
     val h2Driver = "org.h2.Driver"

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventProcessorTest.kt
@@ -104,6 +104,7 @@ class EventProcessorTest : DescribeSpec({
                 }
             }
             class ProjectorWithMetadata {
+                @Suppress("UNUSED_PARAMETER")
                 fun project(event: BarEvent, aggregateId: UUID, metadata: SpecificMetadata, eventId: UUID) {
                     events[aggregateId] = event
                 }
@@ -125,9 +126,11 @@ class EventProcessorTest : DescribeSpec({
     describe("EventListener#eventClasses") {
         it("can derive event classes for handlers") {
             class FirstProjector {
+                @Suppress("UNUSED_PARAMETER")
                 fun project(event: TestEvent, aggregateId: UUID) = Unit
             }
             class SecondProjector {
+                @Suppress("UNUSED_PARAMETER")
                 fun project(event: AnotherTestEvent, aggregateId: UUID) = Unit
             }
 


### PR DESCRIPTION
Let's force the metadata type coming into CommandGateway to be the right type a compile time rather than failing at runtime