### PR TITLE
Make CommandGateway and EventProcessor interfaces

### DIFF
--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
@@ -4,12 +4,9 @@ import com.cultureamp.common.asNestedSealedConcreteClasses
 import java.util.*
 import kotlin.reflect.KClass
 
-class EventProcessor<in M: EventMetadata> (private val domainEventProcessors: Map<KClass<DomainEvent>, (DomainEvent, UUID, M, UUID) -> Any?>) {
-    val eventClasses = domainEventProcessors.keys.flatMap { it.asNestedSealedConcreteClasses() }
-
-    fun process(event: Event<out M>) {
-        domainEventProcessors.filterKeys { it.isInstance(event.domainEvent) }.values.forEach { it(event.domainEvent, event.aggregateId, event.metadata, event.id) }
-    }
+interface EventProcessor<in M: EventMetadata> {
+    fun process(event: Event<out M>)
+    val eventClasses: Collection<KClass<out DomainEvent>>
 
     @Suppress("UNCHECKED_CAST")
     companion object {
@@ -24,17 +21,32 @@ class EventProcessor<in M: EventMetadata> (private val domainEventProcessors: Ma
         inline fun <reified E : DomainEvent> from(domainEventProcessor: DomainEventProcessor<E>): EventProcessor<EventMetadata> {
             val ignoreMetadataHandle = { domainEvent: E, aggregateId: UUID, _: EventMetadata, _: UUID -> domainEventProcessor.process(domainEvent, aggregateId) }
             val handler = (E::class to ignoreMetadataHandle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
-            return EventProcessor(mapOf(handler))
+            return EventTypeInferringEventProcessor(mapOf(handler))
         }
 
         inline fun <reified E : DomainEvent, reified M : EventMetadata> from(domainEventProcessor: DomainEventProcessorWithMetadata<E, M>): EventProcessor<M> {
             val handle = { domainEvent: E, aggregateId: UUID, metadata: M, eventId: UUID -> domainEventProcessor.process(domainEvent, aggregateId, metadata, eventId) }
             val handler = (E::class to handle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
-            return EventProcessor(mapOf(handler))
+            return EventTypeInferringEventProcessor(mapOf(handler))
         }
 
         fun <M : EventMetadata> compose(first: EventProcessor<M>, second: EventProcessor<M>): EventProcessor<M> {
-            return EventProcessor(first.domainEventProcessors + second.domainEventProcessors)
+            return object : EventProcessor<M> {
+                override fun process(event: Event<out M>) {
+                    first.process(event)
+                    second.process(event)
+                }
+
+                override val eventClasses: List<KClass<out DomainEvent>> = first.eventClasses + second.eventClasses
+            }
         }
+    }
+}
+
+class EventTypeInferringEventProcessor<in M: EventMetadata> (private val domainEventProcessors: Map<KClass<DomainEvent>, (DomainEvent, UUID, M, UUID) -> Any?>) : EventProcessor<M> {
+    override val eventClasses = domainEventProcessors.keys.flatMap { it.asNestedSealedConcreteClasses() }.toSet()
+
+    override fun process(event: Event<out M>) {
+        domainEventProcessors.filterKeys { it.isInstance(event.domainEvent) }.values.forEach { it(event.domainEvent, event.aggregateId, event.metadata, event.id) }
     }
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -8,9 +8,9 @@ interface EventSink<M: EventMetadata> {
 }
 
 interface EventSource<out M: EventMetadata>  {
-    fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>> = emptyList(), batchSize: Int = 100) : List<SequencedEvent<out M>>
+    fun getAfter(sequence: Long, eventClasses: Collection<KClass<out DomainEvent>> = emptySet(), batchSize: Int = 100) : List<SequencedEvent<out M>>
 
-    fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
+    fun lastSequence(eventClasses: Collection<KClass<out DomainEvent>> = emptySet()): Long
 }
 
 interface EventStore<M: EventMetadata> : EventSink<M>, EventSource<M> {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -127,7 +127,7 @@ class RelationalDatabaseEventStore<M: EventMetadata> @PublishedApi internal cons
         )
     }
 
-    override fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>>, batchSize: Int): List<SequencedEvent<M>> {
+    override fun getAfter(sequence: Long, eventClasses: Collection<KClass<out DomainEvent>>, batchSize: Int): List<SequencedEvent<M>> {
         return transaction(db) {
             events
                 .select {
@@ -154,7 +154,7 @@ class RelationalDatabaseEventStore<M: EventMetadata> @PublishedApi internal cons
         }
     }
 
-    override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>): Long = transaction(db) {
+    override fun lastSequence(eventClasses: Collection<KClass<out DomainEvent>>): Long = transaction(db) {
         val maxSequence = events.sequence.max()
         events
             .slice(maxSequence)


### PR DESCRIPTION
I was finding I wanted to be able to sub my own implementations for these and having to seriously ugly things to work around the fact that the framework doesn't allow this.