### PR TITLE
Pass metadata through to aggregate command-handlers that want it

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,7 @@ This can then by wired into your [`CommandGateway`](/src/main/kotlin/com/culture
 like so:
 
 ```kotlin
-val routes = listOf(
-    Route.from(SimpleThingAggregate)
-)
-val commandGateway = CommandGateway(eventStore, routes)
+val commandGateway = CommandGateway(eventStore, Route.from(SimpleThingAggregate))
 ```
 
 If you need access to dependencies during command-handling, or want finer grained control over returned error types or
@@ -248,7 +245,8 @@ This can then by wired into your [`CommandGateway`](/src/main/kotlin/com/culture
 like so:
 
 ```kotlin
-val routes = listOf(
+val commandGateway = CommandGateway(
+    eventStore,
     Route.from(
         SurveyAggregate.Companion::create.partial(SurveyNameAlwaysAvailable),
         SurveyAggregate::update.partial2(SurveyNameAlwaysAvailable),
@@ -256,7 +254,6 @@ val routes = listOf(
         SurveyAggregate::updated
     )
 )
-val commandGateway = CommandGateway(eventStore, routes)
 ```
 
 If you happen to have a "stateless" aggregate that doesn't need to update its internal state to handle commands, you
@@ -278,14 +275,14 @@ object PaymentSagaAggregate {
 ```
 
 ```kotlin
-val routes = listOf(
+val gateway = CommandGateway(
+    eventStore,
     Route.fromStateless(
         PaymentSagaAggregate::create,
         PaymentSagaAggregate::update,
         PaymentSagaAggregate
     )
 )
-val gateway = CommandGateway(eventStore, routes)
 ```
 
 ### Event-processors (Projectors and Reactors)

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Aggregate.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Aggregate.kt
@@ -4,103 +4,102 @@ import org.joda.time.DateTime
 import java.util.*
 import kotlin.reflect.KClass
 
-interface SimpleAggregate<UC: UpdateCommand, UE: UpdateEvent> : Aggregate<UC, UE, DomainError, SimpleAggregate<UC, UE>>
-interface SimpleAggregateConstructor<CC: CreationCommand, CE: CreationEvent, UC: UpdateCommand, UE: UpdateEvent> : AggregateConstructor<CC, CE, DomainError, UC, UE, SimpleAggregate<UC, UE>>
+interface SimpleAggregate<UC : UpdateCommand, UE : UpdateEvent, M: EventMetadata> : Aggregate<UC, UE, DomainError, M, SimpleAggregate<UC, UE, M>>
+interface SimpleAggregateConstructor<CC : CreationCommand, CE : CreationEvent, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata> : AggregateConstructor<CC, CE, DomainError, UC, UE, M, SimpleAggregate<UC, UE, M>>
 
-interface SimpleAggregateWithProjection<UC: UpdateCommand, UE: UpdateEvent, P> : AggregateWithProjection<UC, UE, DomainError, P, SimpleAggregateWithProjection<UC, UE, P>>
-interface SimpleAggregateConstructorWithProjection<CC: CreationCommand, CE: CreationEvent, UC: UpdateCommand, UE: UpdateEvent, P> : AggregateConstructorWithProjection<CC, CE, DomainError, UC, UE, P, SimpleAggregateWithProjection<UC, UE, P>>
+interface SimpleAggregateWithProjection<UC : UpdateCommand, UE : UpdateEvent, P> : AggregateWithProjection<UC, UE, DomainError, P, EventMetadata, SimpleAggregateWithProjection<UC, UE, P>>
+interface SimpleAggregateConstructorWithProjection<CC : CreationCommand, CE : CreationEvent, UC : UpdateCommand, UE : UpdateEvent, P> : AggregateConstructorWithProjection<CC, CE, DomainError, UC, UE, P, EventMetadata, SimpleAggregateWithProjection<UC, UE, P>>
 
-
-interface Aggregate<UC: UpdateCommand, UE: UpdateEvent, Err: DomainError, out Self : Aggregate<UC, UE, Err, Self>> {
+interface Aggregate<UC : UpdateCommand, UE : UpdateEvent, Err : DomainError, M : EventMetadata, out Self : Aggregate<UC, UE, Err, M, Self>> {
     fun updated(event: UE): Self
-    fun update(command: UC): Either<Err, List<UE>>
+    fun update(command: UC, metadata: M): Either<Err, List<UE>>
 
     companion object {
-        fun <UC : UpdateCommand, UE : UpdateEvent, Err: DomainError, A : Any> from(
+        fun <UC : UpdateCommand, UE : UpdateEvent, Err : DomainError, M : EventMetadata, A : Any> from(
             aggregate: A,
-            update: A.(UC) -> Either<Err, List<UE>>,
+            update: A.(UC, M) -> Either<Err, List<UE>>,
             updated: A.(UE) -> A = { _ -> this }
-        ): Aggregate<UC, UE, Err, Aggregate<UC, UE, Err, *>> {
-            return object : Aggregate<UC, UE, Err, Aggregate<UC, UE, Err, *>> {
-                override fun updated(event: UE): Aggregate<UC, UE, Err, *> {
+        ): Aggregate<UC, UE, Err, M, Aggregate<UC, UE, Err, M, *>> {
+            return object : Aggregate<UC, UE, Err, M, Aggregate<UC, UE, Err, M, *>> {
+                override fun updated(event: UE): Aggregate<UC, UE, Err, M, *> {
                     val updatedAggregate = aggregate.updated(event)
                     return from(updatedAggregate, update, updated)
                 }
 
-                override fun update(command: UC): Either<Err, List<UE>> {
-                    return aggregate.update(command)
+                override fun update(command: UC, metadata: M): Either<Err, List<UE>> {
+                    return aggregate.update(command, metadata)
                 }
             }
         }
     }
 }
 
-interface AggregateWithProjection<UC: UpdateCommand, UE: UpdateEvent, Err: DomainError, P, Self : AggregateWithProjection<UC, UE, Err, P, Self>> {
+interface AggregateWithProjection<UC : UpdateCommand, UE : UpdateEvent, Err : DomainError, P, M : EventMetadata, Self : AggregateWithProjection<UC, UE, Err, P, M, Self>> {
     fun updated(event: UE): Self
-    fun update(projection: P, command: UC): Either<Err, List<UE>>
+    fun update(projection: P, command: UC, metadata: M): Either<Err, List<UE>>
 
-    fun partial(projection: P): Aggregate<UC, UE, Err, Aggregate<UC, UE, Err, *>> {
-        return object:Aggregate<UC, UE, Err, Aggregate<UC, UE, Err, *>> {
+    fun partial(projection: P): Aggregate<UC, UE, Err, M, Aggregate<UC, UE, Err, M, *>> {
+        return object : Aggregate<UC, UE, Err, M, Aggregate<UC, UE, Err, M, *>> {
 
-            override fun updated(event: UE): Aggregate<UC, UE, Err, *> {
+            override fun updated(event: UE): Aggregate<UC, UE, Err, M, *> {
                 return this@AggregateWithProjection.updated(event).partial(projection)
             }
 
-            override fun update(command: UC): Either<Err, List<UE>> {
-                return update(projection, command)
+            override fun update(command: UC, metadata: M): Either<Err, List<UE>> {
+                return update(projection, command, metadata)
             }
         }
     }
 }
 
-interface AggregateConstructor<CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent, Self: Aggregate<UC, UE, Err, Self>> {
+interface AggregateConstructor<CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata, Self : Aggregate<UC, UE, Err, M, Self>> {
     fun created(event: CE): Self
-    fun create(command: CC): Either<Err, CE>
+    fun create(command: CC, metadata: M): Either<Err, CE>
     fun aggregateType(): String = this::class.companionClassName
 
     companion object {
-        inline fun <CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent, reified A: Any> from(
-            noinline create: (CC) -> Either<Err, CE>,
-            noinline update: A.(UC) -> Either<Err, List<UE>>,
+        inline fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata, reified A : Any> from(
+            noinline create: (CC, M) -> Either<Err, CE>,
+            noinline update: A.(UC, M) -> Either<Err, List<UE>>,
             noinline created: (CE) -> A,
             noinline updated: A.(UE) -> A = { _ -> this },
             noinline aggregateType: () -> String = { A::class.simpleName!! }
-        ): AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>> {
-            return object : AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>> {
-                override fun created(event: CE): Aggregate<UC, UE, Err, *> {
+        ): AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>> {
+            return object : AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>> {
+                override fun created(event: CE): Aggregate<UC, UE, Err, M, *> {
                     val createdAggregate = created(event)
                     return Aggregate.from(createdAggregate, update, updated)
                 }
 
-                override fun create(command: CC): Either<Err, CE> = create(command)
+                override fun create(command: CC, metadata: M): Either<Err, CE> = create(command, metadata)
 
                 override fun aggregateType() = aggregateType()
             }
         }
 
-        inline fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, reified A : Any> fromStateless(
-            noinline create: (CC) -> Either<Err, CE>,
-            noinline update: (UC) -> Either<Err, List<UE>>,
+        inline fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata, reified A : Any> fromStateless(
+            noinline create: (CC, M) -> Either<Err, CE>,
+            noinline update: (UC, M) -> Either<Err, List<UE>>,
             instance: A,
             noinline aggregateType: () -> String = { A::class.simpleName!! }
-        ): AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>> {
-            return from(create, { update(it) }, { instance }, { instance }, aggregateType)
+        ): AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>> {
+            return from(create, { uc: UC, m: M -> update(uc, m) }, { instance }, { instance }, aggregateType)
         }
     }
 }
 
-interface AggregateConstructorWithProjection<CC: CreationCommand, CE: CreationEvent, Err: DomainError, UC: UpdateCommand, UE: UpdateEvent, P, Self : AggregateWithProjection<UC, UE, Err, P, Self>> {
+interface AggregateConstructorWithProjection<CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, P, M : EventMetadata, Self : AggregateWithProjection<UC, UE, Err, P, M, Self>> {
     fun created(event: CE): Self
-    fun create(projection: P, command: CC): Either<Err, CE>
+    fun create(projection: P, command: CC, metadata: M): Either<Err, CE>
     fun aggregateType(): String = this::class.companionClassName
-    fun partial(projection: P): AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>> {
-        return object:AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>> {
-            override fun created(event: CE): Aggregate<UC, UE, Err, *> {
+    fun partial(projection: P): AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>> {
+        return object : AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>> {
+            override fun created(event: CE): Aggregate<UC, UE, Err, M, *> {
                 return this@AggregateConstructorWithProjection.created(event).partial(projection)
             }
 
-            override fun create(command: CC): Either<Err, CE> {
-                return create(projection, command)
+            override fun create(command: CC, metadata: M): Either<Err, CE> {
+                return create(projection, command, metadata)
             }
 
             override fun aggregateType(): String = this@AggregateConstructorWithProjection.aggregateType()
@@ -109,12 +108,12 @@ interface AggregateConstructorWithProjection<CC: CreationCommand, CE: CreationEv
 }
 
 internal fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata>
-    AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.create(
+AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>>.create(
     creationCommand: CC,
     metadata: M,
     eventStore: EventStore<M>
 ): Either<CommandError, Unit> {
-    return create(creationCommand).map { domainEvent ->
+    return create(creationCommand, metadata).map { domainEvent ->
         created(domainEvent) // called to ensure the create event handler doesn't throw any exceptions
         val event = Event(
             id = UUID.randomUUID(),
@@ -130,7 +129,7 @@ internal fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : 
 }
 
 internal fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : UpdateCommand, UE : UpdateEvent, M : EventMetadata>
-    AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.update(
+AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>>.update(
     updateCommand: UC,
     metadata: M,
     events: List<Event<M>>,
@@ -138,7 +137,7 @@ internal fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : 
 ): Either<CommandError, Unit> {
     val aggregate = rehydrate(events)
     return aggregate.flatMap {
-        it.update(updateCommand).flatMap { domainEvents ->
+        it.update(updateCommand, metadata).flatMap { domainEvents ->
             it.updated(domainEvents) // called to ensure the update event handler doesn't throw any exceptions
             val offset = events.last().aggregateSequence + 1
             val createdAt = DateTime()
@@ -160,9 +159,9 @@ internal fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, UC : 
 
 @Suppress("UNCHECKED_CAST")
 private fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, M : EventMetadata, UC : UpdateCommand, UE : UpdateEvent>
-    AggregateConstructor<CC, CE, Err, UC, UE, Aggregate<UC, UE, Err, *>>.rehydrate(
+AggregateConstructor<CC, CE, Err, UC, UE, M, Aggregate<UC, UE, Err, M, *>>.rehydrate(
     events: List<Event<M>>
-): Either<ConstructorTypeMismatch, Aggregate<UC, UE, Err, *>> {
+): Either<ConstructorTypeMismatch, Aggregate<UC, UE, Err, M, *>> {
     val creationEvent = events.first()
     val creationDomainEvent = creationEvent.domainEvent as CE
     val aggregate = if (creationEvent.aggregateType == aggregateType()) {
@@ -175,8 +174,8 @@ private fun <CC : CreationCommand, CE : CreationEvent, Err : DomainError, M : Ev
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun <UC: UpdateCommand, UE: UpdateEvent, Err: DomainError> Aggregate<UC, UE, Err, *>.updated(updateEvents: List<UE>): Aggregate<UC, UE, Err, *> {
-    return updateEvents.fold(this) { aggregate, updateEvent -> aggregate.updated(updateEvent) as Aggregate<UC, UE, Err, *> }
+private fun <UC : UpdateCommand, UE : UpdateEvent, Err : DomainError, M : EventMetadata> Aggregate<UC, UE, Err, M, *>.updated(updateEvents: List<UE>): Aggregate<UC, UE, Err, M, *> {
+    return updateEvents.fold(this) { aggregate, updateEvent -> aggregate.updated(updateEvent) as Aggregate<UC, UE, Err, M, *> }
 }
 
 val <T : Any> KClass<T>.companionClassName get() = if (isCompanion) this.java.declaringClass.simpleName!! else this::class.simpleName!!

--- a/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
@@ -2,12 +2,12 @@ package com.cultureamp.eventsourcing
 
 interface CommandGateway<in M : EventMetadata> {
     companion object {
-        operator fun <M : EventMetadata> invoke(eventStore: EventStore<M>, routes: List<Route<*, *>>) = EventStoreCommandGateway(eventStore, routes)
+        operator fun <M : EventMetadata> invoke(eventStore: EventStore<M>, routes: List<Route<*, *, M>>) = EventStoreCommandGateway(eventStore, routes)
     }
     fun dispatch(command: Command, metadata: M, retries: Int = 5): Either<CommandError, SuccessStatus>
 }
 
-class EventStoreCommandGateway<in M : EventMetadata>(private val eventStore: EventStore<M>, private val routes: List<Route<*, *>>) : CommandGateway<M> {
+class EventStoreCommandGateway<in M : EventMetadata>(private val eventStore: EventStore<M>, private val routes: List<Route<*, *, M>>) : CommandGateway<M> {
     override tailrec fun dispatch(command: Command, metadata: M, retries: Int): Either<CommandError, SuccessStatus> {
         val result = createOrUpdate(command, metadata)
         return if (result is Left && result.error is RetriableError && retries > 0) {
@@ -31,9 +31,9 @@ class EventStoreCommandGateway<in M : EventMetadata>(private val eventStore: Eve
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun constructorFor(command: Command): AggregateConstructor<CreationCommand, CreationEvent, DomainError, UpdateCommand, UpdateEvent, Aggregate<UpdateCommand, UpdateEvent, DomainError, *>>? {
+    private fun constructorFor(command: Command): AggregateConstructor<CreationCommand, CreationEvent, DomainError, UpdateCommand, UpdateEvent, M, Aggregate<UpdateCommand, UpdateEvent, DomainError, M, *>>? {
         val route = routes.find { it.creationCommandClass.isInstance(command) || it.updateCommandClass.isInstance(command) }
-        return route?.aggregateConstructor as AggregateConstructor<CreationCommand, CreationEvent, DomainError, UpdateCommand, UpdateEvent, Aggregate<UpdateCommand, UpdateEvent, DomainError, *>>?
+        return route?.aggregateConstructor as AggregateConstructor<CreationCommand, CreationEvent, DomainError, UpdateCommand, UpdateEvent, M, Aggregate<UpdateCommand, UpdateEvent, DomainError, M, *>>?
     }
 }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
@@ -1,13 +1,13 @@
 package com.cultureamp.eventsourcing
 
-interface CommandGateway<in M : EventMetadata> {
+interface CommandGateway<M : EventMetadata> {
     companion object {
         operator fun <M : EventMetadata> invoke(eventStore: EventStore<M>, routes: List<Route<*, *, M>>) = EventStoreCommandGateway(eventStore, routes)
     }
     fun dispatch(command: Command, metadata: M, retries: Int = 5): Either<CommandError, SuccessStatus>
 }
 
-class EventStoreCommandGateway<in M : EventMetadata>(private val eventStore: EventStore<M>, private val routes: List<Route<*, *, M>>) : CommandGateway<M> {
+class EventStoreCommandGateway<M : EventMetadata>(private val eventStore: EventStore<M>, private val routes: List<Route<*, *, M>>) : CommandGateway<M> {
     override tailrec fun dispatch(command: Command, metadata: M, retries: Int): Either<CommandError, SuccessStatus> {
         val result = createOrUpdate(command, metadata)
         return if (result is Left && result.error is RetriableError && retries > 0) {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/CommandGateway.kt
@@ -2,12 +2,12 @@ package com.cultureamp.eventsourcing
 
 interface CommandGateway<M : EventMetadata> {
     companion object {
-        operator fun <M : EventMetadata> invoke(eventStore: EventStore<M>, routes: List<Route<*, *, M>>) = EventStoreCommandGateway(eventStore, routes)
+        operator fun <M : EventMetadata> invoke(eventStore: EventStore<M>, vararg routes: Route<*, *, M>) = EventStoreCommandGateway(eventStore, *routes)
     }
     fun dispatch(command: Command, metadata: M, retries: Int = 5): Either<CommandError, SuccessStatus>
 }
 
-class EventStoreCommandGateway<M : EventMetadata>(private val eventStore: EventStore<M>, private val routes: List<Route<*, *, M>>) : CommandGateway<M> {
+class EventStoreCommandGateway<M : EventMetadata>(private val eventStore: EventStore<M>, private vararg val routes: Route<*, *, M>) : CommandGateway<M> {
     override tailrec fun dispatch(command: Command, metadata: M, retries: Int): Either<CommandError, SuccessStatus> {
         val result = createOrUpdate(command, metadata)
         return if (result is Left && result.error is RetriableError && retries > 0) {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
@@ -100,6 +100,10 @@ fun <A, B, C> ((A, B) -> C).partial(a: A): (B) -> C {
     return { b -> invoke(a, b) }
 }
 
+fun <A, B, C, D> KFunction3<A, B, C, D>.partial(a: A): (B, C) -> D {
+    return { b, c -> invoke(a, b, c) }
+}
+
 fun <A, B, C, D> KFunction3<A, B, C, D>.partial2(b: B): (A, C) -> D {
     return { a, c -> invoke(a, b, c) }
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
@@ -27,6 +27,14 @@ data class Route<CC : CreationCommand, UC : UpdateCommand, M: EventMetadata>(
             noinline aggregateType: () -> String = { A::class.simpleName!! }
         ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
 
+        inline fun <reified CC: CreationCommand, CE: CreationEvent, Err: DomainError, reified M: EventMetadata, reified UC: UpdateCommand, UE: UpdateEvent, reified A: Any> from(
+            noinline create: (CC) -> Either<Err, CE>,
+            noinline update: A.(UC) -> Either<Err, List<UE>>,
+            noinline created: (CE) -> A,
+            noinline updated: A.(UE) -> A = { _ -> this },
+            noinline aggregateType: () -> String = { A::class.simpleName!! }
+        ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
+
         inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified UC : UpdateCommand, UE : UpdateEvent, reified M : EventMetadata, reified A : Any> fromStateless(
             noinline create: (CC, M) -> Either<Err, CE>,
             noinline update: (UC, M) -> Either<Err, List<UE>>,

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
@@ -2,29 +2,30 @@ package com.cultureamp.eventsourcing
 
 import kotlin.reflect.KClass
 
-data class Route<CC : CreationCommand, UC : UpdateCommand>(
+data class Route<CC : CreationCommand, UC : UpdateCommand, M: EventMetadata>(
     val creationCommandClass: KClass<CC>,
     val updateCommandClass: KClass<UC>,
-    val aggregateConstructor: AggregateConstructor<CC, *, *, UC, *, *>
+    val executionContextClass: KClass<M>,
+    val aggregateConstructor: AggregateConstructor<CC, *, *, UC, *, M, *>
 ) {
     companion object {
-        inline fun <reified CC : CreationCommand, reified UC : UpdateCommand> from(
-            aggregateConstructor: AggregateConstructor<CC, *, *, UC, *, *>
-        ): Route<CC, UC> = Route(CC::class, UC::class, aggregateConstructor)
+        inline fun <reified CC : CreationCommand, reified UC : UpdateCommand, reified M : EventMetadata> from(
+            aggregateConstructor: AggregateConstructor<CC, *, *, UC, *, M, *>
+        ): Route<CC, UC, M> = Route(CC::class, UC::class, M::class, aggregateConstructor)
 
-        inline fun <reified CC: CreationCommand, CE: CreationEvent, Err: DomainError, reified UC: UpdateCommand, UE: UpdateEvent, reified A: Any> from(
-            noinline create: (CC) -> Either<Err, CE>,
-            noinline update: A.(UC) -> Either<Err, List<UE>>,
+        inline fun <reified CC: CreationCommand, CE: CreationEvent, Err: DomainError, reified M: EventMetadata, reified UC: UpdateCommand, UE: UpdateEvent, reified A: Any> from(
+            noinline create: (CC, M) -> Either<Err, CE>,
+            noinline update: A.(UC, M) -> Either<Err, List<UE>>,
             noinline created: (CE) -> A,
             noinline updated: A.(UE) -> A = { _ -> this },
             noinline aggregateType: () -> String = { A::class.simpleName!! }
-        ): Route<CC, UC> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
+        ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
 
-        inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified UC : UpdateCommand, UE : UpdateEvent, reified A : Any> fromStateless(
-            noinline create: (CC) -> Either<Err, CE>,
-            noinline update: (UC) -> Either<Err, List<UE>>,
+        inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified UC : UpdateCommand, UE : UpdateEvent, reified M : EventMetadata, reified A : Any> fromStateless(
+            noinline create: (CC, M) -> Either<Err, CE>,
+            noinline update: (UC, M) -> Either<Err, List<UE>>,
             instance: A,
             noinline aggregateType: () -> String = { A::class.simpleName!! }
-        ): Route<CC, UC> = from(AggregateConstructor.fromStateless(create, update, instance, aggregateType))
+        ): Route<CC, UC, M> = from(AggregateConstructor.fromStateless(create, update, instance, aggregateType))
     }
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
@@ -13,6 +13,12 @@ data class Route<CC : CreationCommand, UC : UpdateCommand, M: EventMetadata>(
             aggregateConstructor: AggregateConstructor<CC, *, *, UC, *, M, *>
         ): Route<CC, UC, M> = Route(CC::class, UC::class, M::class, aggregateConstructor)
 
+        inline fun <reified CC : CreationCommand, reified UC : UpdateCommand, CE : CreationEvent, UE : UpdateEvent, reified M : EventMetadata> from(
+            simpleAggregateConstructor: SimpleAggregateConstructor<CC, CE, UC, UE>
+        ): Route<CC, UC, M> {
+            return from(AggregateConstructor.from<CC, CE, UC, UE, M, SimpleAggregate<UC, UE>>(simpleAggregateConstructor))
+        }
+
         inline fun <reified CC: CreationCommand, CE: CreationEvent, Err: DomainError, reified M: EventMetadata, reified UC: UpdateCommand, UE: UpdateEvent, reified A: Any> from(
             noinline create: (CC, M) -> Either<Err, CE>,
             noinline update: A.(UC, M) -> Either<Err, List<UE>>,

--- a/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
+++ b/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
@@ -112,9 +112,8 @@ fun main(args: Array<String>) {
     }
 
     val commandGateway = CommandGateway(
-        eventStore, listOf(
-            Route.from(SimpleThingAggregate)
-        )
+        eventStore,
+        Route.from(SimpleThingAggregate)
     )
 
     val stop = AtomicBoolean(false)

--- a/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
+++ b/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
@@ -6,6 +6,7 @@ import com.cultureamp.eventsourcing.CreationCommand
 import com.cultureamp.eventsourcing.CreationEvent
 import com.cultureamp.eventsourcing.DomainError
 import com.cultureamp.eventsourcing.DomainEvent
+import com.cultureamp.eventsourcing.Either
 import com.cultureamp.eventsourcing.EventMetadata
 import com.cultureamp.eventsourcing.Left
 import com.cultureamp.eventsourcing.RelationalDatabaseEventStore
@@ -196,18 +197,18 @@ data class Twerked(val tweak: String) : SimpleThingUpdateEvent()
 
 sealed class SimpleThingError : DomainError
 
-data class SimpleThingAggregate(val tweaks: List<String> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
-    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
+data class SimpleThingAggregate(val tweaks: List<String> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent, EventMetadata> {
+    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent, EventMetadata> {
         override fun created(event: SimpleThingCreated) = SimpleThingAggregate()
 
-        override fun create(command: CreateSimpleThing) = Right(SimpleThingCreated)
+        override fun create(command: CreateSimpleThing, metadata: EventMetadata): Either<DomainError, SimpleThingCreated> = Right(SimpleThingCreated)
     }
 
     override fun updated(event: SimpleThingUpdateEvent) = when (event) {
         is Twerked -> this.copy(tweaks = tweaks + event.tweak)
     }
 
-    override fun update(command: SimpleThingUpdateCommand) = when (command) {
+    override fun update(command: SimpleThingUpdateCommand, metadata: EventMetadata) = when (command) {
         is Twerk -> Right.list(Twerked(command.tweak))
     }
 }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
@@ -27,7 +27,8 @@ class AsyncEventProcessorMonitorIntegrationTest : DescribeSpec({
     val eventStore =  RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
     val bookmarksTable = Bookmarks()
     val bookmarkStore = RelationalDatabaseBookmarkStore(db, bookmarksTable)
-    val commandGateway = CommandGateway(eventStore, listOf(
+    val commandGateway = CommandGateway(
+        eventStore,
         Route.from(
             SurveyAggregate.Companion::create.partial(SurveyNameAlwaysAvailable),
             SurveyAggregate::update.partial2(SurveyNameAlwaysAvailable),
@@ -39,8 +40,9 @@ class AsyncEventProcessorMonitorIntegrationTest : DescribeSpec({
             ParticipantAggregate::update,
             ParticipantAggregate.Companion::created,
             ParticipantAggregate::updated
+
         )
-    ))
+    )
 
     beforeTest {
         transaction(db) {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.cultureamp.eventsourcing.example.ParticipantAggregate
 import com.cultureamp.eventsourcing.example.SurveyAggregate
 import com.cultureamp.eventsourcing.example.SurveyNameAlwaysAvailable
 import com.cultureamp.eventsourcing.example.SurveyNamesCommandProjector
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.sql.Database
@@ -23,7 +24,7 @@ class AsyncEventProcessorMonitorIntegrationTest : DescribeSpec({
     val tableH2 = H2DatabaseEventStore.eventsTable()
     val table = if(PgTestConfig.db != null) tableEvent else tableH2
     val eventsSequenceStatsTable = EventsSequenceStats()
-    val eventStore =  RelationalDatabaseEventStore.create<EventMetadata>(db)
+    val eventStore =  RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
     val bookmarksTable = Bookmarks()
     val bookmarkStore = RelationalDatabaseBookmarkStore(db, bookmarksTable)
     val commandGateway = CommandGateway(eventStore, listOf(
@@ -75,8 +76,8 @@ class AsyncEventProcessorMonitorIntegrationTest : DescribeSpec({
             )
 
             val surveyId = UUID.randomUUID()
-            commandGateway.dispatch(CreateSurvey(surveyId, UUID.randomUUID(), emptyMap(), UUID.randomUUID(), DateTime.now()), EventMetadata())
-            commandGateway.dispatch(Invite(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), DateTime.now()), EventMetadata())
+            commandGateway.dispatch(CreateSurvey(surveyId, UUID.randomUUID(), emptyMap(), UUID.randomUUID(), DateTime.now()), StandardEventMetadata("executorId"))
+            commandGateway.dispatch(Invite(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), DateTime.now()), StandardEventMetadata("executorId"))
 
             eventStore.lastSequence() shouldBe 2
             eventStore.lastSequence(listOf(Created::class)) shouldBe 1

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -92,7 +92,7 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             ParticipantAggregate::updated
         )
     )
-    val gateway = CommandGateway(eventStore, routes)
+    val gateway = EventStoreCommandGateway(eventStore, routes)
 
     afterTest {
         transaction(db) {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -3,9 +3,11 @@ package com.cultureamp.eventsourcing
 import com.cultureamp.eventsourcing.example.AddSection
 import com.cultureamp.eventsourcing.example.AlwaysBoppable
 import com.cultureamp.eventsourcing.example.Boop
+import com.cultureamp.eventsourcing.example.BoopWithProjection
 import com.cultureamp.eventsourcing.example.Bop
 import com.cultureamp.eventsourcing.example.Create
 import com.cultureamp.eventsourcing.example.CreateSimpleThing
+import com.cultureamp.eventsourcing.example.CreateSimpleThingWithProjection
 import com.cultureamp.eventsourcing.example.CreateSurvey
 import com.cultureamp.eventsourcing.example.CreateThing
 import com.cultureamp.eventsourcing.example.Delete
@@ -16,9 +18,11 @@ import com.cultureamp.eventsourcing.example.Locale
 import com.cultureamp.eventsourcing.example.LocalizedText
 import com.cultureamp.eventsourcing.example.ParticipantAggregate
 import com.cultureamp.eventsourcing.example.PositionQuestion
+import com.cultureamp.eventsourcing.example.RandomNumberGenerator
 import com.cultureamp.eventsourcing.example.RemoveSection
 import com.cultureamp.eventsourcing.example.SectionNotFound
 import com.cultureamp.eventsourcing.example.SimpleThingAggregate
+import com.cultureamp.eventsourcing.example.SimpleThingWithProjectionAggregate
 import com.cultureamp.eventsourcing.example.StartCreatingSurvey
 import com.cultureamp.eventsourcing.example.SurveyAggregate
 import com.cultureamp.eventsourcing.example.SurveyCaptureLayoutAggregate
@@ -27,6 +31,7 @@ import com.cultureamp.eventsourcing.example.SurveySagaAggregate
 import com.cultureamp.eventsourcing.example.ThingAggregate
 import com.cultureamp.eventsourcing.example.Tweak
 import com.cultureamp.eventsourcing.example.Twerk
+import com.cultureamp.eventsourcing.example.TwerkWithProjection
 import com.cultureamp.eventsourcing.example.Uninvite
 import com.cultureamp.eventsourcing.sample.AddTopping
 import com.cultureamp.eventsourcing.sample.CreateClassicPizza
@@ -64,6 +69,7 @@ class CommandGatewayIntegrationTest : DescribeSpec({
         ),
         Route.from(ThingAggregate.partial(AlwaysBoppable)),
         Route.from(SimpleThingAggregate),
+        Route.from(SimpleThingWithProjectionAggregate.partial(RandomNumberGenerator())),
         Route.fromStateless(
             PaymentSagaAggregate::create,
             PaymentSagaAggregate::update,
@@ -175,6 +181,17 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             gateway.dispatch(CreateSimpleThing(simpleThingId), metadata) shouldBe Right(Created)
             gateway.dispatch(Boop(simpleThingId), metadata) shouldBe Right(Updated)
             gateway.dispatch(Twerk(simpleThingId, "dink"), metadata) shouldBe Right(Updated)
+
+            transaction(db) {
+                eventsTable.selectAll().count() shouldBe 3
+            }
+        }
+
+        it("can route to a simple aggregate with a projection") {
+            val simpleThingId = UUID.randomUUID()
+            gateway.dispatch(CreateSimpleThingWithProjection(simpleThingId), metadata) shouldBe Right(Created)
+            gateway.dispatch(BoopWithProjection(simpleThingId), metadata) shouldBe Right(Updated)
+            gateway.dispatch(TwerkWithProjection(simpleThingId, "dink"), metadata) shouldBe Right(Updated)
 
             transaction(db) {
                 eventsTable.selectAll().count() shouldBe 3

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -166,10 +166,20 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             }
         }
 
-        it("can route to an aggregate created with function handles") {
+        it("can route to an aggregate created with function handles with metadata") {
             val pizzaId = UUID.randomUUID()
             gateway.dispatch(CreateClassicPizza(pizzaId, PizzaStyle.MARGHERITA), metadata) shouldBe Right(Created)
             gateway.dispatch(AddTopping(pizzaId, PizzaTopping.PINEAPPLE), metadata) shouldBe Right(Updated)
+
+            transaction(db) {
+                eventsTable.selectAll().count() shouldBe 2
+            }
+        }
+
+        it("can route to an aggregate created with function handles without metadata") {
+            val surveyCaptureLayoutId = UUID.randomUUID()
+            gateway.dispatch(Generate(surveyCaptureLayoutId, UUID.randomUUID(), DateTime.now()), metadata) shouldBe Right(Created)
+            gateway.dispatch(AddSection(surveyCaptureLayoutId, UUID.randomUUID(), listOf(LocalizedText("hello", Locale.en)), emptyList(), emptyList(), IntendedPurpose.standard, "code", null, DateTime.now()), metadata) shouldBe Right(Updated)
 
             transaction(db) {
                 eventsTable.selectAll().count() shouldBe 2

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -53,7 +53,8 @@ class CommandGatewayIntegrationTest : DescribeSpec({
     val tableH2 = H2DatabaseEventStore.eventsTable()
     val eventsTable = if(PgTestConfig.db != null) table else tableH2
     val eventStore = RelationalDatabaseEventStore.create<StandardEventMetadata>(db)
-    val routes = listOf(
+    val gateway = EventStoreCommandGateway(
+        eventStore,
         Route.from(
             PizzaAggregate.Companion::create,
             PizzaAggregate::update,
@@ -92,7 +93,6 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             ParticipantAggregate::updated
         )
     )
-    val gateway = EventStoreCommandGateway(eventStore, routes)
 
     afterTest {
         transaction(db) {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -60,7 +60,6 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             ::PizzaAggregate,
             PizzaAggregate::updated,
             PizzaAggregate.Companion::aggregateType
-
         ),
         Route.from(ThingAggregate.partial(AlwaysBoppable)),
         Route.from(SimpleThingAggregate),

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PaymentSagaAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PaymentSagaAggregate.kt
@@ -1,14 +1,15 @@
 package com.cultureamp.eventsourcing
 
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import org.joda.time.DateTime
 import java.util.*
 
 object PaymentSagaAggregate {
-    fun create(command: StartPaymentSaga): Either<DomainError, PaymentSagaStarted> = with(command) {
+    fun create(command: StartPaymentSaga, metadata: StandardEventMetadata): Either<DomainError, PaymentSagaStarted> = with(command) {
         Right(PaymentSagaStarted(fromUserId, toUserBankDetails, dollarAmount, DateTime()))
     }
 
-    fun update(command: PaymentSagaUpdateCommand): Either<DomainError, List<PaymentSagaUpdateEvent>> = when (command) {
+    fun update(command: PaymentSagaUpdateCommand, metadata: StandardEventMetadata): Either<DomainError, List<PaymentSagaUpdateEvent>> = when (command) {
         is StartThirdPartyPayment -> Right.list(StartedThirdPartyPayment(command.startedAt))
         is RegisterThirdPartySuccess -> Right.list(FinishedThirdPartyPayment(DateTime()))
         is RegisterThirdPartyFailure -> Right.list(FailedThirdPartyPayment(DateTime()))

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/ParticipantAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/ParticipantAggregate.kt
@@ -3,6 +3,7 @@ package com.cultureamp.eventsourcing.example
 import com.cultureamp.eventsourcing.*
 import org.joda.time.DateTime
 import com.cultureamp.eventsourcing.example.State.*
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import java.util.*
 
 data class ParticipantAggregate(val state: State) {
@@ -10,7 +11,7 @@ data class ParticipantAggregate(val state: State) {
         @Suppress("UNUSED_PARAMETER")
         fun created(event: Invited): ParticipantAggregate = ParticipantAggregate(INVITED)
 
-        fun create(command: Invite): Either<ParticipantError, Invited> = with(command) {
+        fun create(command: Invite, metadata: StandardEventMetadata): Either<ParticipantError, Invited> = with(command) {
             Right(Invited(surveyPeriodId, employeeId, invitedAt))
         }
     }
@@ -21,7 +22,7 @@ data class ParticipantAggregate(val state: State) {
         is Reinvited -> this.copy(state = INVITED)
     }
 
-    fun update(command: ParticipantUpdateCommand): Either<ParticipantError, List<ParticipantUpdateEvent>> =
+    fun update(command: ParticipantUpdateCommand, metadata: StandardEventMetadata): Either<ParticipantError, List<ParticipantUpdateEvent>> =
         when (command) {
             is Invite -> when (state) {
                 INVITED -> Left(AlreadyInvitedException)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/PizzaAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/PizzaAggregate.kt
@@ -91,8 +91,7 @@ data class PizzaAggregate(val baseStyle: PizzaStyle, val toppings: List<PizzaTop
             )
         }
 
-
-        fun create(command: PizzaCreationCommand): Either<PizzaError, PizzaCreated> = when (command) {
+        fun create(command: PizzaCreationCommand, metadata: StandardEventMetadata): Either<PizzaError, PizzaCreated> = when (command) {
             is CreateClassicPizza -> {
                 val initialToppings = classicToppings(command.baseStyle)
                 Right(
@@ -107,7 +106,7 @@ data class PizzaAggregate(val baseStyle: PizzaStyle, val toppings: List<PizzaTop
         fun aggregateType() = "pizza"
     }
 
-    fun update(command: PizzaUpdateCommand): Either<PizzaError, List<PizzaUpdateEvent>> {
+    fun update(command: PizzaUpdateCommand, metadata: StandardEventMetadata): Either<PizzaError, List<PizzaUpdateEvent>> {
         return when (isEaten) {
             true -> Left(PizzaAlreadyEaten())
             false -> when (command) {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
@@ -5,12 +5,14 @@ import com.cultureamp.eventsourcing.CreationCommand
 import com.cultureamp.eventsourcing.CreationEvent
 import com.cultureamp.eventsourcing.DomainError
 import com.cultureamp.eventsourcing.DomainEvent
+import com.cultureamp.eventsourcing.EventMetadata
 import com.cultureamp.eventsourcing.Left
 import com.cultureamp.eventsourcing.Right
 import com.cultureamp.eventsourcing.SimpleAggregate
 import com.cultureamp.eventsourcing.SimpleAggregateConstructor
 import com.cultureamp.eventsourcing.UpdateCommand
 import com.cultureamp.eventsourcing.UpdateEvent
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import java.util.*
 
 sealed class SimpleThingCommand : Command
@@ -33,11 +35,11 @@ object Booped : SimpleThingUpdateEvent()
 sealed class SimpleThingError : DomainError
 object Banged : SimpleThingError()
 
-data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boops: List<Booped> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
-    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
+data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boops: List<Booped> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent, StandardEventMetadata> {
+    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent, StandardEventMetadata> {
         override fun created(event: SimpleThingCreated) = SimpleThingAggregate()
 
-        override fun create(command: CreateSimpleThing) = Right(SimpleThingCreated)
+        override fun create(command: CreateSimpleThing, metadata: StandardEventMetadata) = Right(SimpleThingCreated)
     }
 
     override fun updated(event: SimpleThingUpdateEvent) = when(event){
@@ -45,7 +47,7 @@ data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boop
         is Booped -> this.copy(boops = boops + event)
     }
 
-    override fun update(command: SimpleThingUpdateCommand) = when(command) {
+    override fun update(command: SimpleThingUpdateCommand, metadata: StandardEventMetadata) = when(command) {
         is Twerk -> Right.list(Twerked(command.tweak))
         is Boop -> Right.list(Booped)
         is Bang -> Left(Banged)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
@@ -35,11 +35,11 @@ object Booped : SimpleThingUpdateEvent()
 sealed class SimpleThingError : DomainError
 object Banged : SimpleThingError()
 
-data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boops: List<Booped> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent, StandardEventMetadata> {
-    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent, StandardEventMetadata> {
+data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boops: List<Booped> = emptyList()) : SimpleAggregate<SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
+    companion object : SimpleAggregateConstructor<CreateSimpleThing, SimpleThingCreated, SimpleThingUpdateCommand, SimpleThingUpdateEvent> {
         override fun created(event: SimpleThingCreated) = SimpleThingAggregate()
 
-        override fun create(command: CreateSimpleThing, metadata: StandardEventMetadata) = Right(SimpleThingCreated)
+        override fun create(command: CreateSimpleThing) = Right(SimpleThingCreated)
     }
 
     override fun updated(event: SimpleThingUpdateEvent) = when(event){
@@ -47,7 +47,7 @@ data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boop
         is Booped -> this.copy(boops = boops + event)
     }
 
-    override fun update(command: SimpleThingUpdateCommand, metadata: StandardEventMetadata) = when(command) {
+    override fun update(command: SimpleThingUpdateCommand) = when(command) {
         is Twerk -> Right.list(Twerked(command.tweak))
         is Boop -> Right.list(Booped)
         is Bang -> Left(Banged)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingWithProjectionAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingWithProjectionAggregate.kt
@@ -1,0 +1,57 @@
+package com.cultureamp.eventsourcing.example
+
+import com.cultureamp.eventsourcing.Command
+import com.cultureamp.eventsourcing.CreationCommand
+import com.cultureamp.eventsourcing.CreationEvent
+import com.cultureamp.eventsourcing.DomainError
+import com.cultureamp.eventsourcing.DomainEvent
+import com.cultureamp.eventsourcing.Left
+import com.cultureamp.eventsourcing.Right
+import com.cultureamp.eventsourcing.SimpleAggregateConstructorWithProjection
+import com.cultureamp.eventsourcing.SimpleAggregateWithProjection
+import com.cultureamp.eventsourcing.UpdateCommand
+import com.cultureamp.eventsourcing.UpdateEvent
+import java.util.UUID
+
+sealed class SimpleThingWithProjectionCommand : Command
+
+data class CreateSimpleThingWithProjection(override val aggregateId: UUID) : SimpleThingWithProjectionCommand(), CreationCommand
+
+sealed class SimpleThingUpdateWithProjectionCommand : SimpleThingWithProjectionCommand(), UpdateCommand
+data class TwerkWithProjection(override val aggregateId: UUID, val tweak: String) : SimpleThingUpdateWithProjectionCommand()
+data class BoopWithProjection(override val aggregateId: UUID) : SimpleThingUpdateWithProjectionCommand()
+data class BangWithProjection(override val aggregateId: UUID) : SimpleThingUpdateWithProjectionCommand()
+
+sealed class SimpleThingWithProjectionEvent : DomainEvent
+
+data class SimpleThingWithProjectionCreated(val randomNumber: Int) : SimpleThingWithProjectionEvent(), CreationEvent
+
+sealed class SimpleThingUpdateWithProjectionEvent : SimpleThingWithProjectionEvent(), UpdateEvent
+data class TwerkedWithProjection(val tweak: String, val randomNumber: Int) : SimpleThingUpdateWithProjectionEvent()
+object BoopedWithProjection : SimpleThingUpdateWithProjectionEvent()
+
+sealed class SimpleThingWithProjectionError : DomainError
+object BangedWithProjection : SimpleThingWithProjectionError()
+
+class RandomNumberGenerator {
+    fun randomNumber(): Int = (0..10).random()
+}
+
+data class SimpleThingWithProjectionAggregate(val tweaks: List<String> = emptyList(), val boops: List<BoopedWithProjection> = emptyList()) : SimpleAggregateWithProjection<SimpleThingUpdateWithProjectionCommand, SimpleThingUpdateWithProjectionEvent, RandomNumberGenerator> {
+    companion object : SimpleAggregateConstructorWithProjection<CreateSimpleThingWithProjection, SimpleThingWithProjectionCreated, SimpleThingUpdateWithProjectionCommand, SimpleThingUpdateWithProjectionEvent, RandomNumberGenerator> {
+        override fun created(event: SimpleThingWithProjectionCreated) = SimpleThingWithProjectionAggregate()
+
+        override fun create(projection: RandomNumberGenerator, command: CreateSimpleThingWithProjection) = Right(SimpleThingWithProjectionCreated(projection.randomNumber()))
+    }
+
+    override fun updated(event: SimpleThingUpdateWithProjectionEvent) = when(event){
+        is TwerkedWithProjection -> this.copy(tweaks = tweaks + event.tweak)
+        is BoopedWithProjection -> this.copy(boops = boops + event)
+    }
+
+    override fun update(projection: RandomNumberGenerator, command: SimpleThingUpdateWithProjectionCommand) = when(command) {
+        is TwerkWithProjection -> Right.list(TwerkedWithProjection(command.tweak, projection.randomNumber()))
+        is BoopWithProjection -> Right.list(BoopedWithProjection)
+        is BangWithProjection -> Left(BangedWithProjection)
+    }
+}

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyAggegate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyAggegate.kt
@@ -1,6 +1,7 @@
 package com.cultureamp.eventsourcing.example
 
 import com.cultureamp.eventsourcing.*
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import org.joda.time.DateTime
 import java.util.*
 
@@ -8,7 +9,7 @@ data class SurveyAggregate(val name: Map<Locale, String>, val accountId: UUID, v
     constructor(event: Created): this(event.name, event.accountId)
 
     companion object {
-        fun create(query: SurveyNamesQuery, command: SurveyCreationCommand): Either<SurveyError, Created> = when (command) {
+        fun create(query: SurveyNamesQuery, command: SurveyCreationCommand, metadata: StandardEventMetadata): Either<SurveyError, Created> = when (command) {
             is CreateSurvey -> when {
                 command.name.any { (locale, name) -> query.nameExistsFor(command.accountId, name, locale)} -> Left(SurveyNameNotUnique)
                 else -> Right(Created(command.name, command.accountId, command.createdAt))
@@ -22,7 +23,7 @@ data class SurveyAggregate(val name: Map<Locale, String>, val accountId: UUID, v
         is Restored -> this.copy(deleted = false)
     }
 
-    fun update(query: SurveyNamesQuery, command: SurveyUpdateCommand): Either<SurveyError, List<SurveyUpdateEvent>> = when (command) {
+    fun update(query: SurveyNamesQuery, command: SurveyUpdateCommand, metadata: StandardEventMetadata): Either<SurveyError, List<SurveyUpdateEvent>> = when (command) {
         is Rename -> when {
             name.get(command.locale) == command.newName -> Left(AlreadyRenamed)
             query.nameExistsFor(accountId, command.newName, command.locale) -> Left(SurveyNameNotUnique)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyCaptureLayoutAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyCaptureLayoutAggregate.kt
@@ -19,7 +19,7 @@ data class SurveyCaptureLayoutAggregate(
             is Snapshot -> with(event) { SurveyCaptureLayoutAggregate(sectionsForIntendedPurpose, demographicSectionsPlacement, questions) }
         }
 
-        fun create(command: SurveyCaptureLayoutCreationCommand, metadata: StandardEventMetadata): Either<SurveyCaptureLayoutCommandError, Generated> = when (command) {
+        fun create(command: SurveyCaptureLayoutCreationCommand): Either<SurveyCaptureLayoutCommandError, Generated> = when (command) {
             is Generate -> with(command) { Right(Generated(surveyId, generatedAt)) }
         }
     }
@@ -82,7 +82,7 @@ data class SurveyCaptureLayoutAggregate(
         }
     }
 
-    fun update(command: SurveyCaptureLayoutUpdateCommand, metadata: StandardEventMetadata): Either<SurveyCaptureLayoutCommandError, List<SurveyCaptureLayoutUpdateEvent>> = when (command) {
+    fun update(command: SurveyCaptureLayoutUpdateCommand): Either<SurveyCaptureLayoutCommandError, List<SurveyCaptureLayoutUpdateEvent>> = when (command) {
         is AddSection -> when {
             hasSection(command.sectionId) -> Left(SectionAlreadyAdded)
             hasSectionCode(command.code) -> Left(SectionCodeNotUnique)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyCaptureLayoutAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyCaptureLayoutAggregate.kt
@@ -4,6 +4,7 @@ import com.cultureamp.eventsourcing.*
 import org.joda.time.DateTime
 import com.cultureamp.eventsourcing.example.DemographicSectionPosition.bottom
 import com.cultureamp.eventsourcing.example.DemographicSectionPosition.top
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import java.util.UUID
 
 
@@ -18,7 +19,7 @@ data class SurveyCaptureLayoutAggregate(
             is Snapshot -> with(event) { SurveyCaptureLayoutAggregate(sectionsForIntendedPurpose, demographicSectionsPlacement, questions) }
         }
 
-        fun create(command: SurveyCaptureLayoutCreationCommand): Either<SurveyCaptureLayoutCommandError, Generated> = when (command) {
+        fun create(command: SurveyCaptureLayoutCreationCommand, metadata: StandardEventMetadata): Either<SurveyCaptureLayoutCommandError, Generated> = when (command) {
             is Generate -> with(command) { Right(Generated(surveyId, generatedAt)) }
         }
     }
@@ -81,7 +82,7 @@ data class SurveyCaptureLayoutAggregate(
         }
     }
 
-    fun update(command: SurveyCaptureLayoutUpdateCommand): Either<SurveyCaptureLayoutCommandError, List<SurveyCaptureLayoutUpdateEvent>> = when (command) {
+    fun update(command: SurveyCaptureLayoutUpdateCommand, metadata: StandardEventMetadata): Either<SurveyCaptureLayoutCommandError, List<SurveyCaptureLayoutUpdateEvent>> = when (command) {
         is AddSection -> when {
             hasSection(command.sectionId) -> Left(SectionAlreadyAdded)
             hasSectionCode(command.code) -> Left(SectionCodeNotUnique)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveySagaAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveySagaAggregate.kt
@@ -1,8 +1,17 @@
 package com.cultureamp.eventsourcing.example
 
-import com.cultureamp.eventsourcing.*
+import com.cultureamp.eventsourcing.Command
+import com.cultureamp.eventsourcing.CreationCommand
+import com.cultureamp.eventsourcing.CreationEvent
+import com.cultureamp.eventsourcing.DomainError
+import com.cultureamp.eventsourcing.DomainEvent
+import com.cultureamp.eventsourcing.Either
+import com.cultureamp.eventsourcing.Right
+import com.cultureamp.eventsourcing.UpdateCommand
+import com.cultureamp.eventsourcing.UpdateEvent
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import org.joda.time.DateTime
-import java.util.*
+import java.util.UUID
 
 data class SurveySagaAggregate(val surveyAggregateId: UUID,
                                val surveyCaptureLayoutAggregateId: UUID,
@@ -18,7 +27,7 @@ data class SurveySagaAggregate(val surveyAggregateId: UUID,
     )
 
     companion object {
-        fun create(command: SurveySagaCreationCommand): Either<DomainError, SurveySagaStarted> = when (command) {
+        fun create(command: SurveySagaCreationCommand, metadata: StandardEventMetadata): Either<DomainError, SurveySagaStarted> = when (command) {
             is Create -> with(command) {
                 val startEvent = SurveySagaStarted(
                     surveyAggregateId = surveyAggregateId,
@@ -33,7 +42,7 @@ data class SurveySagaAggregate(val surveyAggregateId: UUID,
         }
     }
 
-    fun update(command: SurveySagaUpdateCommand): Either<DomainError, List<SurveySagaUpdateEvent>> = Right.list(
+    fun update(command: SurveySagaUpdateCommand, metadata: StandardEventMetadata): Either<DomainError, List<SurveySagaUpdateEvent>> = Right.list(
         when (command) {
             is StartCreatingSurvey -> StartedCreatingSurvey(
                 CreateSurvey(

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/ThingAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/ThingAggregate.kt
@@ -8,10 +8,12 @@ import com.cultureamp.eventsourcing.CreationEvent
 import com.cultureamp.eventsourcing.DomainError
 import com.cultureamp.eventsourcing.DomainEvent
 import com.cultureamp.eventsourcing.Either
+import com.cultureamp.eventsourcing.EventMetadata
 import com.cultureamp.eventsourcing.Left
 import com.cultureamp.eventsourcing.Right
 import com.cultureamp.eventsourcing.UpdateCommand
 import com.cultureamp.eventsourcing.UpdateEvent
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import java.util.*
 
 sealed class ThingCommand : Command
@@ -44,13 +46,13 @@ object AlwaysBoppable : ThingCommandProjection {
     override fun isBoppable() = true
 }
 
-data class ThingAggregate(val tweaks: List<String> = emptyList(), val bops: List<Bopped> = emptyList()) : AggregateWithProjection<ThingUpdateCommand, ThingUpdateEvent, ThingError, ThingCommandProjection, ThingAggregate> {
-    companion object : AggregateConstructorWithProjection<ThingCreationCommand, ThingCreationEvent, ThingError, ThingUpdateCommand, ThingUpdateEvent, ThingCommandProjection, ThingAggregate> {
+data class ThingAggregate(val tweaks: List<String> = emptyList(), val bops: List<Bopped> = emptyList()) : AggregateWithProjection<ThingUpdateCommand, ThingUpdateEvent, ThingError, ThingCommandProjection, StandardEventMetadata, ThingAggregate> {
+    companion object : AggregateConstructorWithProjection<ThingCreationCommand, ThingCreationEvent, ThingError, ThingUpdateCommand, ThingUpdateEvent, ThingCommandProjection, StandardEventMetadata, ThingAggregate> {
         override fun created(event: ThingCreationEvent): ThingAggregate = when(event) {
             is ThingCreated -> ThingAggregate()
         }
 
-        override fun create(projection: ThingCommandProjection, command: ThingCreationCommand): Either<ThingError, ThingCreationEvent> = when(command){
+        override fun create(projection: ThingCommandProjection, command: ThingCreationCommand, metadata: StandardEventMetadata): Either<ThingError, ThingCreationEvent> = when(command){
             is CreateThing -> Right(ThingCreated)
         }
 
@@ -62,7 +64,7 @@ data class ThingAggregate(val tweaks: List<String> = emptyList(), val bops: List
         is Bopped -> this.copy(bops = bops + event)
     }
 
-    override fun update(projection: ThingCommandProjection, command: ThingUpdateCommand): Either<ThingError, List<ThingUpdateEvent>> = when(command) {
+    override fun update(projection: ThingCommandProjection, command: ThingUpdateCommand, metadata: StandardEventMetadata): Either<ThingError, List<ThingUpdateEvent>> = when(command) {
         is Tweak -> Right.list(Tweaked(command.tweak))
         is Bop -> when(projection.isBoppable()) {
             false -> Left(Unboppable)


### PR DESCRIPTION
The reason we want this is that in our new application we want to separate the command (frontend/user provided data) from the execution context (userId, accountId, perhaps role data etc.). The reason we wanted to do that for even just the MVP release the app will have at least 55 commands, which would usually mean 55 web routes where all they did was smoosh together the frontend data and jwt data into a command and send it along the command gateway. We'd like to make this generic by having a single endpoint to field all command types automagically (by detecting the command class and marshalling onto it), and passing the execution context (from the jwt) separately (in this case, using the event metadata which contains `userId` and `accountId` already).

Metadata probably isn't the right container for passing this through into the aggregate since Metadata's sole responsibility is to just be a packet of context data to sink alongside the event. However, introducing a new `ExecutionContext` generic parameter and method argument will introduce significant complexity, and pragmatically the metadata will often carry the cross-cutting data we need inside of the aggregate. We can revisit this again in the future the first time this doesn't hold true.