### PR TITLE
Support singleton events

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.11.0
+base_version=0.11.1
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -5,7 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
 import com.fasterxml.jackson.datatype.joda.JodaModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import com.fasterxml.jackson.module.kotlin.kotlinModule
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Database
@@ -28,7 +29,7 @@ import java.util.UUID
 import kotlin.reflect.KClass
 
 val defaultObjectMapper = ObjectMapper()
-    .registerKotlinModule()
+    .registerModule(kotlinModule { singletonSupport(SingletonSupport.CANONICALIZE) })
     .registerModule(JodaModule())
     .configure(WRITE_DATES_AS_TIMESTAMPS, false)
     .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -189,11 +189,10 @@ class CommandGatewayIntegrationTest : DescribeSpec({
         it("can route to a simple aggregate") {
             val simpleThingId = UUID.randomUUID()
             gateway.dispatch(CreateSimpleThing(simpleThingId), metadata) shouldBe Right(Created)
-            gateway.dispatch(Boop(simpleThingId), metadata) shouldBe Right(Updated)
             gateway.dispatch(Twerk(simpleThingId, "dink"), metadata) shouldBe Right(Updated)
 
             transaction(db) {
-                eventsTable.selectAll().count() shouldBe 3
+                eventsTable.selectAll().count() shouldBe 2
             }
         }
 
@@ -279,6 +278,17 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             gateway.dispatch(CreateSurvey(surveyId, UUID.randomUUID(), mapOf(Locale.en to "name"), UUID.randomUUID(), DateTime.now()), metadata) shouldBe Right(Created)
             gateway.dispatch(Invite(surveyId, UUID.randomUUID(), UUID.randomUUID(), DateTime.now()), metadata) shouldBe
                 Left(ConstructorTypeMismatch("ParticipantAggregate", SurveyCreated::class))
+        }
+
+        it("supports singleton/object events") {
+            val simpleThingId = UUID.randomUUID()
+            gateway.dispatch(CreateSimpleThing(simpleThingId), metadata) shouldBe Right(Created)
+            gateway.dispatch(Boop(simpleThingId), metadata) shouldBe Right(Updated) // singleton event
+            gateway.dispatch(Twerk(simpleThingId, "booped"), metadata) shouldBe Right(Updated)
+
+            transaction(db) {
+                eventsTable.selectAll().count() shouldBe 3
+            }
         }
     }
 })

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SimpleThingAggregate.kt
@@ -44,7 +44,7 @@ data class SimpleThingAggregate(val tweaks: List<String> = emptyList(), val boop
 
     override fun updated(event: SimpleThingUpdateEvent) = when(event){
         is Twerked -> this.copy(tweaks = tweaks + event.tweak)
-        is Booped -> this.copy(boops = boops + event)
+        Booped -> this.copy(boops = boops + Booped)
     }
 
     override fun update(command: SimpleThingUpdateCommand) = when(command) {


### PR DESCRIPTION
We decided in Develop Module that we didn't want to store timestamps inside every domain event because it was redundant. This left us in a situation where there was an event with no fields, and the compiler won't let you have an event without fields. If you instead use an `object` as the compiler instructs you to do, there was a [bug in Jackson](https://github.com/FasterXML/jackson-module-kotlin/issues/141) where when it deserialized a singleton object, it was technically a new instance of that singleton rather than the same canonical instance. This would cause `SingletonInstance == deserializedInstance` to fail even though `SingletonInstance` was an `object`/singleton, and `deserializedInstance is SingletonInstance` would still pass. This has since been [fixed in Jackson](https://github.com/FasterXML/jackson-module-kotlin/pull/244) and we can configure it to properly support singletons, as we do in this PR.