### PR TITLE
Upgrade dependency checker to remove error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("com.cinnober.gradle:semver-git:2.3.1")
-        classpath("org.owasp:dependency-check-gradle:6.4.1.1")
+        classpath("org.owasp:dependency-check-gradle:6.5.0.1")
     }
 }
 
@@ -152,7 +152,6 @@ dependencies {
     implementation "org.jetbrains.exposed:exposed-jodatime:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:2.0.11"
     implementation "org.postgresql:postgresql:42.2.23"
-    implementation "org.owasp:dependency-check-gradle:6.4.1.1"
 }
 
 


### PR DESCRIPTION
Seems to remove annoying 
```
Cannot choose between the following variants of org.owasp:dependency-check-gradle:6.4.1.1:
          - javadocElements
          - sourcesElements
```
Error