### PR TITLE
Event driven projectors [TACT-256] [TACT-728]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ dependencies {
     implementation "org.jetbrains.exposed:exposed-jdbc:$exposed_version"
     implementation "org.jetbrains.exposed:exposed-jodatime:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:2.0.11"
-    implementation "org.postgresql:postgresql:42.2.23"
+    testImplementation "org.postgresql:postgresql:42.2.23"
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.15.0
+base_version=0.16.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/common/ExponentialBackoff.kt
+++ b/src/main/kotlin/com/cultureamp/common/ExponentialBackoff.kt
@@ -8,7 +8,7 @@ class ExponentialBackoff(
 	val failureBackoffMs: (attempt: Int) -> Long = exponentialBackoffAlgorithm(
 		600_000, 2
 	),
-	val sleeper: (millis: Long) -> Unit = { Thread.sleep(it) },
+	val sleeper: (millis: Long) -> Unit = defaultSleeper,
 	val onFailure: (error: Throwable, consecutiveFailures: Int) -> Unit
 ) {
 	companion object {
@@ -58,4 +58,13 @@ sealed class Action {
 	object Continue : Action()
 	object Stop : Action()
 	data class Error(val exception: Throwable) : Action()
+}
+
+val defaultSleeper : (millis: Long) -> Unit = { Thread.sleep(it) }
+val interruptibleSleeper : (millis: Long) -> Unit = { millis ->
+	try {
+		Thread.sleep(millis)
+	} catch (e: InterruptedException) {
+		Thread.currentThread().interrupt() // restore interrupted status
+	}
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -94,4 +94,6 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
+
+    fun processedSequence() = bookmarkStore.bookmarkFor(bookmarkName).sequence
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -19,9 +19,9 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
     private val startLog: (Bookmark) -> Unit = { bookmark ->
         System.out.println("Polling for events for ${bookmark.name} from sequence ${bookmark.sequence}")
     },
-    private val endLog: (Int, Bookmark, Long, Long) -> Unit = { count, bookmark, minLatency, maxLatency ->
+    private val endLog: (Int, Bookmark) -> Unit = { count, bookmark ->
         if (count > 0 || Random.nextFloat() < 0.01) {
-            System.out.println("Finished processing batch for ${bookmark.name}, $count events up to sequence ${bookmark.sequence}, latency between $minLatency and $maxLatency")
+            System.out.println("Finished processing batch for ${bookmark.name}, $count events up to sequence ${bookmark.sequence}")
         }
     },
     private val upcasting: Boolean = true,
@@ -36,9 +36,9 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
         startLog: (Bookmark) -> Unit = { bookmark ->
             System.out.println("Polling for events for ${bookmark.name} from sequence ${bookmark.sequence}")
         },
-        endLog: (Int, Bookmark, Long, Long) -> Unit = { count, bookmark, minLatency, maxLatency ->
+        endLog: (Int, Bookmark) -> Unit = { count, bookmark ->
             if (count > 0 || Random.nextFloat() < 0.01) {
-                System.out.println("Finished processing batch for ${bookmark.name}, $count events up to sequence ${bookmark.sequence}, latency between $minLatency and $maxLatency")
+                System.out.println("Finished processing batch for ${bookmark.name}, $count events up to sequence ${bookmark.sequence}")
             }
         },
         upcasting: Boolean = true,
@@ -95,7 +95,7 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
             index + 1 to updatedBookmark
         }
 
-        endLog(count, finalBookmark, minLatency, maxLatency)
+        endLog(count, finalBookmark)
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -99,6 +99,4 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
-
-    fun processedSequence() = bookmarkStore.bookmarkFor(bookmarkName).sequence
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -56,8 +56,6 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
 
         startLog(startBookmark)
 
-        var minLatency = Long.MAX_VALUE
-        var maxLatency = 0L
         val (count, finalBookmark) = eventSource.getAfter(startBookmark.sequence, sequencedEventProcessor.domainEventClasses(), batchSize).foldIndexed(
             0 to startBookmark
         ) { index, _, sequencedEvent ->
@@ -89,9 +87,6 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
 
             val updatedBookmark = startBookmark.copy(sequence = sequencedEvent.sequence)
             bookmarkStore.save(updatedBookmark)
-            val latency = System.currentTimeMillis() - sequencedEvent.event.createdAt.millis
-            minLatency = minLatency.coerceAtMost(latency)
-            maxLatency = maxLatency.coerceAtLeast(latency)
             index + 1 to updatedBookmark
         }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -24,7 +24,7 @@ import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.vendors.H2Dialect
 import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
-import org.postgresql.util.PSQLException
+import java.sql.SQLException
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -272,7 +272,7 @@ fun Transaction.pgAdvisoryXactLock(): CommandError? {
     try {
         exec("SET LOCAL lock_timeout = '${lockTimeoutMilliseconds}ms';")
         exec("SELECT pg_advisory_xact_lock(-1)")
-    } catch (e: PSQLException) {
+    } catch (e: SQLException) {
         if (e.message.orEmpty().contains("canceling statement due to lock timeout")) {
             return LockingError
         } else {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
@@ -5,7 +5,6 @@ import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.StringColumnType
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
-import org.postgresql.util.PGobject
 
 /**
  * Modified from: https://gist.github.com/quangIO/a623b5caa53c703e252d858f7a806919
@@ -19,14 +18,10 @@ private class Jsonb : StringColumnType() {
     override fun sqlType() = "jsonb"
 
     override fun setParameter(stmt: PreparedStatementApi, index: Int, value: Any?) {
-        val obj = PGobject()
-        obj.type = "jsonb"
-        obj.value = value as String
-        stmt[index] = obj
+        stmt[index] = value as String
     }
 
     override fun valueFromDB(value: Any): Any {
-        value as PGobject
-        return value.value as Any
+        return value
     }
 }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CachingBookmarkStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CachingBookmarkStoreTest.kt
@@ -1,0 +1,46 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.core.spec.style.DescribeSpec
+import org.jetbrains.exposed.sql.Database
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.transactions.transaction
+
+class CachingBookmarkStoreTest : DescribeSpec({
+    val db = PgTestConfig.db ?: Database.connect(url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    val store = RelationalDatabaseBookmarkStore(db)
+    val cachedStore = CachingBookmarkStore(store)
+
+    beforeTest {
+        transaction(db) {
+            SchemaUtils.create(store.table)
+        }
+    }
+
+    afterTest {
+        transaction(db) {
+            SchemaUtils.drop(store.table)
+        }
+    }
+
+    describe("RelationalDatabaseBookmarkStore") {
+        it("sets and retrieves a bookmark") {
+            cachedStore.save(Bookmark("new-bookmark", 123L))
+            cachedStore.save(Bookmark("other-bookmark", 456L))
+            cachedStore.bookmarkFor("new-bookmark") shouldBe Bookmark("new-bookmark", 123L)
+        }
+
+        it("returns zero for an unknown bookmark") {
+            cachedStore.bookmarkFor("other-new-bookmark") shouldBe Bookmark("other-new-bookmark", 0L)
+        }
+
+        it("updates the value if the bookmark already exists") {
+            cachedStore.save(Bookmark("update-bookmark", 123L))
+            cachedStore.save(Bookmark("other-bookmark", 456L))
+            cachedStore.save(Bookmark("update-bookmark", 789L))
+            cachedStore.bookmarkFor("update-bookmark") shouldBe Bookmark("update-bookmark", 789L)
+        }
+    }
+})
+
+


### PR DESCRIPTION
### Summary

Some changes to Kestrel to support [event-driven projectors](https://github.com/cultureamp/develop-module/pull/820)

### Code Changes

1. Remove run-time dependencies on PostgreSQL JDBC (so we can use [PGJDBC-NG](https://impossibl.github.io/pgjdbc-ng/)) 
2. Add a caching bookmark store, so we don't have to hit DB to check if bookmark is higher than notification
3. Create some options for sleeper in `ExponentialBackoff`

### TODO

Would love to move some of the code from develop's `EventProcessors` into Kestrel. Will probably need to at some stage. 