### PR TITLE
Make EventProcessor.compose() additive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,8 @@ buildscript {
         classpath("org.owasp:dependency-check-gradle:6.5.0.1")
     }
 }
-
 apply plugin: 'kotlin'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "org.owasp.dependencycheck"
 
@@ -22,7 +21,7 @@ archivesBaseName = "kestrel"
 
 sourceSets {
     main.kotlin.srcDirs = main.java.srcDirs = ["src/main/kotlin"]
-    test.kotlin.srcDirs = test.java.srcDirs = ["src/test/kotlin"]
+    test.kotlin.srcDirs = test.java.srcDirs = ["src/test/java", "src/test/kotlin"]
 }
 
 
@@ -46,30 +45,32 @@ dependencyCheck {
     analyzers.assemblyEnabled = false
 }
 
-artifacts {
-    archives javadocJar, sourcesJar
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
-uploadArchives {
+publishing {
     repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
+        maven {
+            def releasesUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsUrl : releasesUrl
+            credentials {
+                username = System.getenv('SONATYPE_USERNAME')
+                password = System.getenv('SONATYPE_PASSWORD')
             }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: System.getenv('SONATYPE_USERNAME'), password: System.getenv('SONATYPE_PASSWORD'))
-            }
-
-            pom.project {
-                name 'Kestrel'
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description 'Kotlin Framework for running event-sourced services'
-                url 'https://github.com/cultureamp/kestrel'
-
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = "kestrel"
+            from components.java
+            pom {
+                name = "Kestrel"
+                description = "Kotlin Framework for running event-sourced services"
+                packaging = 'jar'
+                url = 'https://github.com/cultureamp/kestrel'
                 scm {
                     connection = 'scm:git@github.com:cultureamp/kestrel.git'
                     developerConnection = 'scm:git@github.com:cultureamp/kestrel.git'
@@ -78,8 +79,8 @@ uploadArchives {
 
                 licenses {
                     license {
-                        name 'The Apache License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
                     }
                 }
 
@@ -94,11 +95,15 @@ uploadArchives {
         }
     }
 }
-
 signing {
-    useGpgCmd()
-    sign configurations.archives
+    def skipSigning = Boolean.valueOf(System.getenv("SKIP_SIGNING"))
+    if (!skipSigning)
+    {
+        useGpgCmd()
+        sign publishing.publications.mavenJava
+    }
 }
+
 
 javadoc {
     if(JavaVersion.current().isJava9Compatible()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.12.0
+base_version=0.14.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Apr 03 17:52:20 AEDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
@@ -15,7 +15,7 @@ interface EventProcessor<in M : EventMetadata> {
         inline fun <reified E : DomainEvent, reified M : EventMetadata> from(noinline process: (E, UUID, M, UUID) -> Any?) = CompositeDomainEventProcessor.from(process)
         inline fun <reified E : DomainEvent> from(domainEventProcessor: DomainEventProcessor<E>) = CompositeDomainEventProcessor.from(domainEventProcessor)
         inline fun <reified E : DomainEvent, reified M : EventMetadata> from(domainEventProcessor: DomainEventProcessorWithMetadata<E, M>) = CompositeDomainEventProcessor.from(domainEventProcessor)
-        fun <M : EventMetadata> compose(first: CompositeDomainEventProcessor<M>, second: CompositeDomainEventProcessor<M>) = CompositeDomainEventProcessor.compose(first, second)
+        fun <M : EventMetadata> compose(first: CompositeDomainEventProcessor<M>, vararg remainder: CompositeDomainEventProcessor<M>) = CompositeDomainEventProcessor.compose(first, *remainder)
     }
 
     fun process(event: Event<out M>)
@@ -53,8 +53,8 @@ class CompositeDomainEventProcessor<in M : EventMetadata> (private val domainEve
             return CompositeDomainEventProcessor(listOf(handler))
         }
 
-        fun <M : EventMetadata> compose(first: CompositeDomainEventProcessor<M>, second: CompositeDomainEventProcessor<M>): CompositeDomainEventProcessor<M> {
-            return CompositeDomainEventProcessor(first.domainEventProcessors + second.domainEventProcessors)
+        fun <M : EventMetadata> compose(first: CompositeDomainEventProcessor<M>, vararg remainder: CompositeDomainEventProcessor<M>): CompositeDomainEventProcessor<M> {
+            return CompositeDomainEventProcessor(first.domainEventProcessors + remainder.flatMap { it.domainEventProcessors })
         }
     }
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventProcessor.kt
@@ -22,13 +22,13 @@ interface EventProcessor<in M : EventMetadata> {
     fun domainEventClasses(): List<KClass<out DomainEvent>> = emptyList()
 }
 
-class CompositeDomainEventProcessor<in M : EventMetadata> (private val domainEventProcessors: Map<KClass<DomainEvent>, (DomainEvent, UUID, M, UUID) -> Any?>) : EventProcessor<M> {
-    val eventClasses = domainEventProcessors.keys.flatMap { it.asNestedSealedConcreteClasses() }
+class CompositeDomainEventProcessor<in M : EventMetadata> (private val domainEventProcessors: List<Pair<KClass<DomainEvent>, (DomainEvent, UUID, M, UUID) -> Any?>>) : EventProcessor<M> {
+    val eventClasses = domainEventProcessors.flatMap { it.first.asNestedSealedConcreteClasses() }
 
     override fun domainEventClasses() = eventClasses
 
     override fun process(event: Event<out M>) {
-        domainEventProcessors.filterKeys { it.isInstance(event.domainEvent) }.values.forEach { it(event.domainEvent, event.aggregateId, event.metadata, event.id) }
+        domainEventProcessors.filter { it.first.isInstance(event.domainEvent) }.forEach { it.second(event.domainEvent, event.aggregateId, event.metadata, event.id) }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -44,13 +44,13 @@ class CompositeDomainEventProcessor<in M : EventMetadata> (private val domainEve
         inline fun <reified E : DomainEvent> from(domainEventProcessor: DomainEventProcessor<E>): CompositeDomainEventProcessor<EventMetadata> {
             val ignoreMetadataHandle = { domainEvent: E, aggregateId: UUID, _: EventMetadata, _: UUID -> domainEventProcessor.process(domainEvent, aggregateId) }
             val handler = (E::class to ignoreMetadataHandle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
-            return CompositeDomainEventProcessor(mapOf(handler))
+            return CompositeDomainEventProcessor(listOf(handler))
         }
 
         inline fun <reified E : DomainEvent, reified M : EventMetadata> from(domainEventProcessor: DomainEventProcessorWithMetadata<E, M>): CompositeDomainEventProcessor<M> {
             val handle = { domainEvent: E, aggregateId: UUID, metadata: M, eventId: UUID -> domainEventProcessor.process(domainEvent, aggregateId, metadata, eventId) }
             val handler = (E::class to handle) as Pair<KClass<DomainEvent>, (DomainEvent, UUID, EventMetadata, UUID) -> Any?>
-            return CompositeDomainEventProcessor(mapOf(handler))
+            return CompositeDomainEventProcessor(listOf(handler))
         }
 
         fun <M : EventMetadata> compose(first: CompositeDomainEventProcessor<M>, second: CompositeDomainEventProcessor<M>): CompositeDomainEventProcessor<M> {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
@@ -6,7 +6,6 @@ import org.jetbrains.exposed.sql.StringColumnType
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
 import org.postgresql.util.PGobject
-import java.sql.PreparedStatement
 
 /**
  * Modified from: https://gist.github.com/quangIO/a623b5caa53c703e252d858f7a806919

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
@@ -100,8 +100,8 @@ class RelationalDatabaseEventStoreTest : DescribeSpec({
         it("gets the concurrency error from the sink") {
             val aggregateId = UUID.randomUUID()
             val events = listOf(
-                event(PizzaCreated(MARGHERITA, listOf(TOMATO_PASTE)), aggregateId, 1, StandardEventMetadata("unused")),
-                event(PizzaEaten(), aggregateId, 1, StandardEventMetadata("unused")),
+                event(PizzaCreated(MARGHERITA, listOf(TOMATO_PASTE)), aggregateId, 1, StandardEventMetadata(/* unused */UUID.randomUUID())),
+                event(PizzaEaten(), aggregateId, 1, StandardEventMetadata(/* unused */UUID.randomUUID())),
             )
             store.sink(events, aggregateId) shouldBe Left(ConcurrencyError)
         }


### PR DESCRIPTION
### Description

Two main changes
1. Upgrade to gradle 7.4.2, use `maven-publish` gradle plugin rather than deprecated `maven` (to get build working for me on jdk11)
2. Change the `EventProcessor.compose()` function to be "additive" rather than "selective" - ie henceforth if there is more than one function capable of processing a particular event, then all the functions will be executed (in order) rather than just the last. 
  a. Also change `compose()` to support more than 2 parameters