### PR TITLE
Make EventsSequenceStats optional for updating from EventStore sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 0.22.0
+
+## Breaking changes
+
+This release moves makes the updating of `EventsSequenceStats` during `RelationalDatabaseEventStore#sink` optional, 
+so that applications can choose to not to this synchronously and update these 
+stats asynchronously.
+
+This moves the `#lastSequence(...)` method out of the `EventSource` interface and onto a new
+`EventsSequenceStats` class. To migrate, just switch over to calling the method
+in its new location.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.21.0
+base_version=0.22.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitor.kt
@@ -1,19 +1,18 @@
 package com.cultureamp.eventsourcing
 
-class AsyncEventProcessorMonitor<M: EventMetadata>(
+class AsyncEventProcessorMonitor<M : EventMetadata>(
     private val asyncEventProcessors: List<AsyncEventProcessor<M>>,
-    private val metrics: (Lag) -> Unit
+    private val metrics: (Lag) -> Unit,
 ) {
     fun run() {
         val lags = asyncEventProcessors.map {
             val bookmarkSequence = it.bookmarkStore.bookmarkFor(it.bookmarkName).sequence
-            val lastSequence = it.eventSource.lastSequence(it.sequencedEventProcessor.domainEventClasses())
+            val lastSequence = it.eventsSequenceStats.lastSequence(it.sequencedEventProcessor.domainEventClasses())
             Lag(
                 name = it.bookmarkName,
                 bookmarkSequence = bookmarkSequence,
-                lastSequence = lastSequence
+                lastSequence = lastSequence,
             )
-
         }
 
         lags.forEach {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -24,11 +24,12 @@ interface BookmarkedEventProcessor<M : EventMetadata> {
 }
 
 interface AsyncEventProcessor<M : EventMetadata> : BookmarkedEventProcessor<M> {
+    val eventSource: EventSource<M>
     val eventsSequenceStats: EventsSequenceStats
 }
 
 class BatchedAsyncEventProcessor<M : EventMetadata>(
-    val eventSource: EventSource<M>,
+    override val eventSource: EventSource<M>,
     override val eventsSequenceStats: EventsSequenceStats,
     override val bookmarkStore: BookmarkStore,
     override val bookmarkName: String,

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEventProcessor.kt
@@ -24,11 +24,12 @@ interface BookmarkedEventProcessor<M : EventMetadata> {
 }
 
 interface AsyncEventProcessor<M : EventMetadata> : BookmarkedEventProcessor<M> {
-    val eventSource: EventSource<M>
+    val eventsSequenceStats: EventsSequenceStats
 }
 
 class BatchedAsyncEventProcessor<M : EventMetadata>(
-    override val eventSource: EventSource<M>,
+    val eventSource: EventSource<M>,
+    override val eventsSequenceStats: EventsSequenceStats,
     override val bookmarkStore: BookmarkStore,
     override val bookmarkName: String,
     override val sequencedEventProcessor: SequencedEventProcessor<M>,
@@ -47,6 +48,7 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
 
     constructor(
         eventSource: EventSource<M>,
+        eventsSequenceStats: EventsSequenceStats,
         bookmarkStore: BookmarkStore,
         bookmarkName: String,
         eventProcessor: EventProcessor<M>,
@@ -62,7 +64,7 @@ class BatchedAsyncEventProcessor<M : EventMetadata>(
         upcasting: Boolean = true,
         stats: StatisticsCollector? = null,
     ) : this(
-        eventSource, bookmarkStore, bookmarkName, SequencedEventProcessor.from(eventProcessor), batchSize, startLog, endLog, upcasting, stats,
+        eventSource, eventsSequenceStats, bookmarkStore, bookmarkName, SequencedEventProcessor.from(eventProcessor), batchSize, startLog, endLog, upcasting, stats,
     )
 
     fun processOneBatch(): Action {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -3,17 +3,14 @@ package com.cultureamp.eventsourcing
 import java.util.UUID
 import kotlin.reflect.KClass
 
-interface EventSink<M: EventMetadata> {
+interface EventSink<M : EventMetadata> {
     fun sink(newEvents: List<Event<M>>, aggregateId: UUID): Either<CommandError, Long>
 }
 
-interface EventSource<out M: EventMetadata>  {
-    fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>> = emptyList(), batchSize: Int = 100) : List<SequencedEvent<out M>>
-
-    fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
+interface EventSource<out M : EventMetadata> {
+    fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>> = emptyList(), batchSize: Int = 100): List<SequencedEvent<out M>>
 }
 
-interface EventStore<M: EventMetadata> : EventSink<M>, EventSource<M> {
+interface EventStore<M : EventMetadata> : EventSink<M>, EventSource<M> {
     fun eventsFor(aggregateId: UUID): List<Event<M>>
 }
-

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
@@ -28,8 +28,6 @@ class RelationalDatabaseEventsSequenceStats(
 
     fun createSchemaIfNotExists() {
         transaction(db) {
-            println("creating table ${table.tableName}")
-            addLogger(StdOutSqlLogger)
             SchemaUtils.create(table)
         }
     }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
@@ -3,7 +3,9 @@ package com.cultureamp.eventsourcing
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.max
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -14,7 +16,7 @@ val defaultEventsSequenceStatsTableName = "events_sequence_stats"
 
 interface EventsSequenceStats {
     fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
-    fun update(eventType: String, sequence: Long)
+    fun update(eventClass: KClass<out DomainEvent>, sequence: Long)
 }
 
 class RelationalDatabaseEventsSequenceStats(
@@ -26,13 +28,15 @@ class RelationalDatabaseEventsSequenceStats(
 
     fun createSchemaIfNotExists() {
         transaction(db) {
+            println("creating table ${table.tableName}")
+            addLogger(StdOutSqlLogger)
             SchemaUtils.create(table)
         }
     }
 
-    override fun update(eventType: String, sequence: Long) = transaction(db) {
+    override fun update(eventClass: KClass<out DomainEvent>, sequence: Long) = transaction(db) {
         table.upsert {
-            it[table.eventType] = eventType
+            it[table.eventType] = eventTypeResolver.serialize(eventClass.java)
             it[table.sequence] = sequence
         }
         Unit

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
@@ -3,9 +3,7 @@ package com.cultureamp.eventsourcing
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.max
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -16,7 +14,7 @@ val defaultEventsSequenceStatsTableName = "events_sequence_stats"
 
 interface EventsSequenceStats {
     fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
-    fun update(eventClass: KClass<out DomainEvent>, sequence: Long)
+    fun save(eventClass: KClass<out DomainEvent>, sequence: Long)
 }
 
 class RelationalDatabaseEventsSequenceStats(
@@ -32,7 +30,7 @@ class RelationalDatabaseEventsSequenceStats(
         }
     }
 
-    override fun update(eventClass: KClass<out DomainEvent>, sequence: Long) = transaction(db) {
+    override fun save(eventClass: KClass<out DomainEvent>, sequence: Long) = transaction(db) {
         table.upsert {
             it[table.eventType] = eventTypeResolver.serialize(eventClass.java)
             it[table.sequence] = sequence

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
@@ -1,0 +1,61 @@
+package com.cultureamp.eventsourcing
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.max
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.upsert
+import kotlin.reflect.KClass
+
+val defaultEventsSequenceStatsTableName = "events_sequence_stats"
+
+interface EventsSequenceStats {
+    fun lastSequence(eventClasses: List<KClass<out DomainEvent>> = emptyList()): Long
+    fun update(eventType: String, sequence: Long)
+}
+
+class RelationalDatabaseEventsSequenceStats(
+    private val db: Database,
+    private val eventTypeResolver: EventTypeResolver = defaultEventTypeResolver,
+    tableName: String = defaultEventsSequenceStatsTableName,
+) : EventsSequenceStats {
+    val table = EventsSequenceStatsTable(tableName)
+
+    fun createSchemaIfNotExists() {
+        transaction(db) {
+            SchemaUtils.create(table)
+        }
+    }
+
+    override fun update(eventType: String, sequence: Long) = transaction(db) {
+        table.upsert {
+            it[table.eventType] = eventType
+            it[table.sequence] = sequence
+        }
+        Unit
+    }
+
+    override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>): Long = transaction(db) {
+        val maxSequence = table.sequence.max()
+        table
+            .slice(maxSequence)
+            .select {
+                if (eventClasses.isNotEmpty()) {
+                    table.eventType.inList(eventClasses.map { eventTypeResolver.serialize(it.java) })
+                } else {
+                    Op.TRUE
+                }
+            }
+            .map { it[maxSequence] }
+            .first() ?: 0
+    }
+}
+
+class EventsSequenceStatsTable(tableName: String = defaultEventsSequenceStatsTableName) : Table(tableName) {
+    val eventType = varchar("event_type", 256)
+    override val primaryKey = PrimaryKey(eventType)
+    val sequence = long("sequence")
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -38,7 +38,7 @@ val defaultEventTypeResolver = CanonicalNameEventTypeResolver
 class RelationalDatabaseEventStore<M : EventMetadata> @PublishedApi internal constructor(
     private val db: Database,
     val events: Events,
-    private val eventsSequenceStats: EventsSequenceStats?,
+    val eventsSequenceStats: EventsSequenceStats?,
     private val metadataClass: Class<M>,
     private val objectMapper: ObjectMapper,
     private val eventTypeResolver: EventTypeResolver,

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -101,7 +101,7 @@ class RelationalDatabaseEventStore<M : EventMetadata> @PublishedApi internal con
                             SequencedEvent(event, -1)
                         } else {
                             val insertedSequence = insertResult[eventsSinkTable.sequence]
-                            eventsSequenceStats?.update(event.domainEvent::class, insertedSequence)
+                            eventsSequenceStats?.save(event.domainEvent::class, insertedSequence)
                             SequencedEvent(event, insertedSequence)
                         }
                     }.let { Right(it) }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -101,7 +101,7 @@ class RelationalDatabaseEventStore<M : EventMetadata> @PublishedApi internal con
                             SequencedEvent(event, -1)
                         } else {
                             val insertedSequence = insertResult[eventsSinkTable.sequence]
-                            eventsSequenceStats?.update(eventType, insertedSequence)
+                            eventsSequenceStats?.update(event.domainEvent::class, insertedSequence)
                             SequencedEvent(event, insertedSequence)
                         }
                     }.let { Right(it) }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BlockingAsyncEventProcessorWaiterTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BlockingAsyncEventProcessorWaiterTest.kt
@@ -58,7 +58,6 @@ class BlockingAsyncEventProcessorWaiterTest : DescribeSpec({
 
 val alwaysFailsEventSource = object : EventSource<SpecificMetadata> {
     override fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>>, batchSize: Int) = fail("Should not be called")
-    override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>) = fail("Should not be called")
 }
 
 fun bookmarkStoreCountingUpFrom(sequence: Long, allowedBookmarkNames: Set<String>) = object : BookmarkStore {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
@@ -48,9 +48,6 @@ class EventConsumerStatisticsTest : DescribeSpec({
             return result.map { SequencedEvent(it.first, seq++) }
         }
 
-//        override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>): Long {
-//            return seq + events.size
-//        }
 
         override fun eventsFor(aggregateId: UUID): List<Event<EventMetadata>> {
             val results = events.filter { it.second == aggregateId }.map { it.first }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
@@ -57,7 +57,7 @@ class EventConsumerStatisticsTest : DescribeSpec({
     }
     val eventsSequenceStats = object : EventsSequenceStats {
         override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>) = fail("Should not be called")
-        override fun update(eventClass: KClass<out DomainEvent>, sequence: Long) = fail("Should not be called")
+        override fun save(eventClass: KClass<out DomainEvent>, sequence: Long) = fail("Should not be called")
     }
 
     val table = Bookmarks()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
@@ -60,7 +60,7 @@ class EventConsumerStatisticsTest : DescribeSpec({
     }
     val eventsSequenceStats = object : EventsSequenceStats {
         override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>) = fail("Should not be called")
-        override fun update(eventType: String, sequence: Long) = fail("Should not be called")
+        override fun update(eventClass: KClass<out DomainEvent>, sequence: Long) = fail("Should not be called")
     }
 
     val table = Bookmarks()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
@@ -24,10 +24,10 @@ class EventsSequenceStatsTest : DescribeSpec({
     eventsSequenceStats.createSchemaIfNotExists()
 
     fun updateSequence(eventClass: KClass<out DomainEvent>, sequence: Long) {
-        eventsSequenceStats.update(eventClass, sequence)
+        eventsSequenceStats.save(eventClass, sequence)
 
         // Idempotency
-        eventsSequenceStats.update(eventClass, sequence)
+        eventsSequenceStats.save(eventClass, sequence)
     }
 
     describe("RelationalDatabaseEventsSequenceStats") {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
@@ -1,0 +1,47 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.eventsourcing.example.Created
+import com.cultureamp.eventsourcing.example.Deleted
+import com.cultureamp.eventsourcing.example.Renamed
+import com.cultureamp.eventsourcing.example.Restored
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.sql.Database
+import org.testcontainers.containers.PostgreSQLContainer
+import kotlin.reflect.KClass
+
+class EventsSequenceStatsTest : DescribeSpec({
+    // using postgres because h2 has a bug in the "upsert" method
+    val postgres = PostgreSQLContainer("postgres:14.3")
+    postgres.start()
+    val db = Database.connect(
+        url = postgres.getJdbcUrl(),
+        user = postgres.getUsername(),
+        password = postgres.getPassword(),
+    )
+
+    val eventsSequenceStats = RelationalDatabaseEventsSequenceStats(db)
+    eventsSequenceStats.createSchemaIfNotExists()
+
+    fun updateSequence(eventClass: KClass<out DomainEvent>, sequence: Long) {
+        eventsSequenceStats.update(eventClass, sequence)
+
+        // Idempotency
+        eventsSequenceStats.update(eventClass, sequence)
+    }
+
+    describe("RelationalDatabaseEventsSequenceStats") {
+        it("exposes max sequence given event types") {
+            updateSequence(Created::class, 1)
+            updateSequence(Renamed::class, 2)
+            updateSequence(Deleted::class, 3)
+
+            eventsSequenceStats.lastSequence(listOf(Created::class)) shouldBe 1
+            eventsSequenceStats.lastSequence(listOf(Renamed::class)) shouldBe 2
+            eventsSequenceStats.lastSequence(listOf(Deleted::class)) shouldBe 3
+            eventsSequenceStats.lastSequence(listOf(Created::class, Deleted::class)) shouldBe 3
+            eventsSequenceStats.lastSequence(listOf()) shouldBe 3
+            eventsSequenceStats.lastSequence(listOf(Restored::class)) shouldBe 0
+        }
+    }
+})


### PR DESCRIPTION
This is a breaking change on the API for where the `lastSequence` method lives, because the EventStore doesn't always have the context for performantly fetching this value. This is now a responsibility of `EventsSequenceStats` standalone class