### PR TITLE
update Jackson to 2.18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,8 @@ compileTestKotlin {
 }
 
 dependencies {
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.18.1"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.18.1"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jackson_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "io.kotest:kotest-runner-junit5-jvm:4.6.2" // for kotest framework
     testImplementation "io.kotest:kotest-assertions-core-jvm:4.6.2" // for kotest core jvm assertions

--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,8 @@ compileTestKotlin {
 }
 
 dependencies {
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.12.5"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.12.5"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.18.1"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.18.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "io.kotest:kotest-runner-junit5-jvm:4.6.2" // for kotest framework
     testImplementation "io.kotest:kotest-assertions-core-jvm:4.6.2" // for kotest core jvm assertions

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,6 @@ targetJvmVersion=17
 nexus_repository_root=https://package-repository.continuous-integration.cultureamp.net/repository/maven-
 exposed_version=0.49.0
 kotlin_version=1.9.23
+jackson_version=2.18.1
 
 signing.gnupg.executable=gpg

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
 import com.fasterxml.jackson.datatype.joda.JodaModule
-import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import com.fasterxml.jackson.module.kotlin.KotlinFeature
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Column
@@ -27,7 +27,7 @@ import java.util.UUID
 import kotlin.reflect.KClass
 
 val defaultObjectMapper = ObjectMapper()
-    .registerModule(kotlinModule { singletonSupport(SingletonSupport.CANONICALIZE) })
+    .registerModule(kotlinModule { enable(KotlinFeature.SingletonSupport) })
     .registerModule(JodaModule())
     .configure(WRITE_DATES_AS_TIMESTAMPS, false)
     .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)


### PR DESCRIPTION
Method `singletonSupport` in `KotlinModule.Builder` was removed in `jackson-module-kotlin` 2.18.0, making kestrel incompatible was Jackson versions >=2.18.0.

This change bumps Jackson dependency to 2.18.1 and updates the module registration call to work with the new way to enable singleton support.