### PR TITLE
All aggregates to see metadata during rehydration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.23.0
+base_version=0.24.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/Route.kt
@@ -23,8 +23,25 @@ data class Route<CC : CreationCommand, UC : UpdateCommand, M : EventMetadata>(
         inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified M : EventMetadata, reified UC : UpdateCommand, UE : UpdateEvent, reified A : Any> from(
             noinline create: (CC, M) -> Either<Err, Pair<CE, List<UE>>>,
             noinline update: A.(UC, M) -> Either<Err, List<UE>>,
+            noinline created: (CE, M) -> A,
+            noinline updated: A.(UE, M) -> A = { _,_ -> this },
+            noinline aggregateType: () -> String = { A::class.simpleName!! }
+        ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
+
+        @JvmName("fromCreationCommandReturningMultipleEvents")
+        inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified M : EventMetadata, reified UC : UpdateCommand, UE : UpdateEvent, reified A : Any> from(
+            noinline create: (CC, M) -> Either<Err, Pair<CE, List<UE>>>,
+            noinline update: A.(UC, M) -> Either<Err, List<UE>>,
             noinline created: (CE) -> A,
             noinline updated: A.(UE) -> A = { _ -> this },
+            noinline aggregateType: () -> String = { A::class.simpleName!! }
+        ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
+
+        inline fun <reified CC : CreationCommand, CE : CreationEvent, Err : DomainError, reified M : EventMetadata, reified UC : UpdateCommand, UE : UpdateEvent, reified A : Any> from(
+            noinline create: (CC, M) -> Either<Err, CE>,
+            noinline update: A.(UC, M) -> Either<Err, List<UE>>,
+            noinline created: (CE, M) -> A,
+            noinline updated: A.(UE, M) -> A = { _,_ -> this },
             noinline aggregateType: () -> String = { A::class.simpleName!! }
         ): Route<CC, UC, M> = from(AggregateConstructor.from(create, update, created, updated, aggregateType))
 

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AggregateTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AggregateTest.kt
@@ -3,8 +3,19 @@ package com.cultureamp.eventsourcing
 import com.cultureamp.eventsourcing.example.ParticipantAggregate
 import com.cultureamp.eventsourcing.example.SimpleThingAggregate
 import com.cultureamp.eventsourcing.example.ThingAggregate
+import com.cultureamp.eventsourcing.sample.EatPizza
+import com.cultureamp.eventsourcing.sample.PizzaAggregate
+import com.cultureamp.eventsourcing.sample.PizzaCreated
+import com.cultureamp.eventsourcing.sample.PizzaMustBeEatenByLastPersonWhoEdittedIt
+import com.cultureamp.eventsourcing.sample.PizzaOnDifferentAccount
+import com.cultureamp.eventsourcing.sample.PizzaStyle
+import com.cultureamp.eventsourcing.sample.PizzaTopping
+import com.cultureamp.eventsourcing.sample.PizzaToppingAdded
+import com.cultureamp.eventsourcing.sample.PizzaUpdateCommand
+import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import java.util.UUID
 
 class AggregateTest : DescribeSpec({
     describe("aggregateType") {
@@ -52,6 +63,22 @@ class AggregateTest : DescribeSpec({
                 PaymentSagaAggregate
             ) { "paymentSaga" }
             aggregateConstructor.aggregateType() shouldBe "paymentSaga"
+        }
+
+        it("aggregates can be constructed that accept metadata when rehydrating") {
+            val aggregateConstructor = AggregateConstructor.from(
+                PizzaAggregate.Companion::create,
+                PizzaAggregate::update,
+                ::PizzaAggregate,
+                PizzaAggregate::updated
+            )
+            aggregateConstructor.aggregateType() shouldBe "PizzaAggregate"
+            val metadata = StandardEventMetadata(accountId = UUID.randomUUID(), executorId = UUID.randomUUID())
+            val pizzaAggregate = aggregateConstructor.created(PizzaCreated(PizzaStyle.HAWAIIAN, initialToppings = emptyList()), metadata)
+            pizzaAggregate.update(EatPizza(UUID.randomUUID()), metadata.copy(accountId = UUID.randomUUID())) shouldBe Left(PizzaOnDifferentAccount)
+            val secondMetadata = metadata.copy(executorId = UUID.randomUUID())
+            val updatedPizza = pizzaAggregate.updated(PizzaToppingAdded(PizzaTopping.BASIL), secondMetadata) as Aggregate<PizzaUpdateCommand, *, *, StandardEventMetadata, *>
+            updatedPizza.update(EatPizza(UUID.randomUUID()), metadata) shouldBe Left(PizzaMustBeEatenByLastPersonWhoEdittedIt)
         }
     }
 })

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -174,7 +174,7 @@ class CommandGatewayIntegrationTest : DescribeSpec({
             val aggregateId = UUID.randomUUID()
             val result = gateway.dispatch(CreateClassicPizza(aggregateId, PizzaStyle.MARGHERITA), metadata)
             result shouldBe Right(Created)
-            val result2 = gateway.dispatch(EatPizza(aggregateId), StandardEventMetadata(accountId))
+            val result2 = gateway.dispatch(EatPizza(aggregateId), StandardEventMetadata(accountId, executorId))
             result2 shouldBe Right(Updated)
             val result3 = gateway.dispatch(AddTopping(aggregateId, PizzaTopping.PINEAPPLE), metadata)
             result3.shouldBeInstanceOf<Left<PizzaAlreadyEaten>>()


### PR DESCRIPTION
`created` and `updated` methods on aggregates can now include `metadata` if they want to use that data to check invariants. This is optional and this change remains fully backward compatible.