### PR TITLE
Allow EventTypeResolvers to return aggregate types with event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,11 @@ stats asynchronously.
 This moves the `#lastSequence(...)` method out of the `EventSource` interface and onto a new
 `EventsSequenceStats` class. To migrate, just switch over to calling the method
 in its new location.
+
+# 0.25.0
+
+## Breaking changes
+
+The interface for `EventTypeResolver` has changed to support the event-store filtering by `aggregate-type` 
+along side `event-type`. This will only affect codebases that provided a custom implementation of this interface.
+See `PackageRemovingEventTypeResolver` for an example of how to work with the new interface.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.24.0
+base_version=0.25.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventTypeResolver.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventTypeResolver.kt
@@ -1,0 +1,30 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.common.asNestedSealedConcreteClasses
+import kotlin.reflect.KClass
+
+interface EventTypeResolver {
+    fun serialize(domainEventClass: Class<out DomainEvent>): String
+    fun deserialize(aggregateType: String, eventType: String): Class<out DomainEvent>
+}
+
+object CanonicalNameEventTypeResolver : EventTypeResolver {
+    override fun serialize(domainEventClass: Class<out DomainEvent>) = domainEventClass.canonicalName
+    override fun deserialize(aggregateType: String, eventType: String) = eventType.asClass<DomainEvent>()!!
+}
+
+class PackageRemovingEventTypeResolver(vararg eventClasses: KClass<out DomainEvent>) : EventTypeResolver {
+    private val eventTypeToClass = run {
+        val allConcreteClasses = eventClasses.flatMap { it.asNestedSealedConcreteClasses().toSet() }
+        val allConcreteClassSimpleNames = allConcreteClasses.map { it.simpleName!! }
+        val duplicates = allConcreteClassSimpleNames.groupBy { it }.mapValues { it.value.size }.filter { it.value > 1 }
+        if (duplicates.isNotEmpty()) {
+            throw IllegalArgumentException("Event names ${duplicates.keys} exist in more than one aggregate")
+        }
+        allConcreteClassSimpleNames.zip(allConcreteClasses).toMap()
+    }
+
+    override fun deserialize(aggregateType: String, eventType: String) = eventTypeToClass.getValue(eventType).java
+
+    override fun serialize(domainEventClass: Class<out DomainEvent>) = domainEventClass.simpleName
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -230,14 +230,3 @@ fun Transaction.pgAdvisoryXactLock(): CommandError? {
     }
     return null
 }
-
-interface EventTypeResolver {
-    fun serialize(domainEventClass: Class<out DomainEvent>): String
-    fun deserialize(aggregateType: String, eventType: String): Class<out DomainEvent>
-}
-
-object CanonicalNameEventTypeResolver : EventTypeResolver {
-    override fun serialize(domainEventClass: Class<out DomainEvent>) = domainEventClass.canonicalName
-
-    override fun deserialize(aggregateType: String, eventType: String) = eventType.asClass<DomainEvent>()!!
-}

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PackageRemovingEventTypeResolverTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PackageRemovingEventTypeResolverTest.kt
@@ -1,0 +1,40 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.developmodule.eventsourcing.bar.BarEvent
+import com.cultureamp.developmodule.eventsourcing.baz.BazEvent
+import com.cultureamp.developmodule.eventsourcing.baz.FirstBazEvent
+import com.cultureamp.developmodule.eventsourcing.baz.SecondBazEvent
+import com.cultureamp.developmodule.eventsourcing.foo.FirstFooEvent
+import com.cultureamp.developmodule.eventsourcing.foo.FooEvent
+import com.cultureamp.developmodule.eventsourcing.foo.SameNameEvent
+import io.kotest.core.spec.style.DescribeSpec
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+
+internal class PackageRemovingEventTypeResolverTest : DescribeSpec({
+    describe("RelationalDatabaseEventsSequenceStats") {
+        it("fails with meaningful error when same event name exists in multiple aggregates") {
+            val error = Assertions.assertThrows(IllegalArgumentException::class.java) {
+                PackageRemovingEventTypeResolver(FooEvent::class, BarEvent::class)
+            }
+            assertEquals("Event names [SameNameEvent] exist in more than one aggregate", error.message)
+        }
+
+        it("allows event types to be persisted without full package names") {
+            val eventTypeResolver = PackageRemovingEventTypeResolver(FooEvent::class, BazEvent::class)
+
+            assertEquals("FirstFooEvent", eventTypeResolver.serialize(FirstFooEvent::class.java))
+            assertEquals("SameNameEvent", eventTypeResolver.serialize(SameNameEvent::class.java))
+            assertEquals("FirstBazEvent", eventTypeResolver.serialize(FirstBazEvent::class.java))
+            assertEquals("SecondBazEvent", eventTypeResolver.serialize(SecondBazEvent::class.java))
+            assertEquals(FirstFooEvent::class.java, eventTypeResolver.deserialize("unused", "FirstFooEvent"))
+            assertEquals(SameNameEvent::class.java, eventTypeResolver.deserialize("unused", "SameNameEvent"))
+            assertEquals(FirstBazEvent::class.java, eventTypeResolver.deserialize("unused", "FirstBazEvent"))
+            assertEquals(SecondBazEvent::class.java, eventTypeResolver.deserialize("unused", "SecondBazEvent"))
+
+            Assertions.assertThrows(NoSuchElementException::class.java) {
+                eventTypeResolver.deserialize("", "ThirdFooEvent")
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PackageRemovingEventTypeResolverTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PackageRemovingEventTypeResolverTest.kt
@@ -1,10 +1,13 @@
 package com.cultureamp.eventsourcing
 
+import com.cultureamp.developmodule.eventsourcing.bar.BarAggregate
 import com.cultureamp.developmodule.eventsourcing.bar.BarEvent
+import com.cultureamp.developmodule.eventsourcing.baz.BazAggregate
 import com.cultureamp.developmodule.eventsourcing.baz.BazEvent
 import com.cultureamp.developmodule.eventsourcing.baz.FirstBazEvent
 import com.cultureamp.developmodule.eventsourcing.baz.SecondBazEvent
 import com.cultureamp.developmodule.eventsourcing.foo.FirstFooEvent
+import com.cultureamp.developmodule.eventsourcing.foo.FooAggregate
 import com.cultureamp.developmodule.eventsourcing.foo.FooEvent
 import com.cultureamp.developmodule.eventsourcing.foo.SameNameEvent
 import io.kotest.core.spec.style.DescribeSpec
@@ -15,25 +18,25 @@ internal class PackageRemovingEventTypeResolverTest : DescribeSpec({
     describe("RelationalDatabaseEventsSequenceStats") {
         it("fails with meaningful error when same event name exists in multiple aggregates") {
             val error = Assertions.assertThrows(IllegalArgumentException::class.java) {
-                PackageRemovingEventTypeResolver(FooEvent::class, BarEvent::class)
+                PackageRemovingEventTypeResolver(mapOf(FooAggregate::class to FooEvent::class, BarAggregate::class to BarEvent::class))
             }
             assertEquals("Event names [SameNameEvent] exist in more than one aggregate", error.message)
         }
 
         it("allows event types to be persisted without full package names") {
-            val eventTypeResolver = PackageRemovingEventTypeResolver(FooEvent::class, BazEvent::class)
+            val eventTypeResolver = PackageRemovingEventTypeResolver(mapOf(FooAggregate::class to FooEvent::class, BazAggregate::class to BazEvent::class))
 
-            assertEquals("FirstFooEvent", eventTypeResolver.serialize(FirstFooEvent::class.java))
-            assertEquals("SameNameEvent", eventTypeResolver.serialize(SameNameEvent::class.java))
-            assertEquals("FirstBazEvent", eventTypeResolver.serialize(FirstBazEvent::class.java))
-            assertEquals("SecondBazEvent", eventTypeResolver.serialize(SecondBazEvent::class.java))
-            assertEquals(FirstFooEvent::class.java, eventTypeResolver.deserialize("unused", "FirstFooEvent"))
-            assertEquals(SameNameEvent::class.java, eventTypeResolver.deserialize("unused", "SameNameEvent"))
-            assertEquals(FirstBazEvent::class.java, eventTypeResolver.deserialize("unused", "FirstBazEvent"))
-            assertEquals(SecondBazEvent::class.java, eventTypeResolver.deserialize("unused", "SecondBazEvent"))
+            assertEquals(EventTypeDescription("FirstFooEvent", "FooAggregate"), eventTypeResolver.serialize(FirstFooEvent::class.java))
+            assertEquals(EventTypeDescription("SameNameEvent", "FooAggregate"), eventTypeResolver.serialize(SameNameEvent::class.java))
+            assertEquals(EventTypeDescription("FirstBazEvent", "BazAggregate"), eventTypeResolver.serialize(FirstBazEvent::class.java))
+            assertEquals(EventTypeDescription("SecondBazEvent", "BazAggregate"), eventTypeResolver.serialize(SecondBazEvent::class.java))
+            assertEquals(FirstFooEvent::class.java, eventTypeResolver.deserialize(EventTypeDescription("FirstFooEvent", "FooAggregate")))
+            assertEquals(SameNameEvent::class.java, eventTypeResolver.deserialize(EventTypeDescription("SameNameEvent", "FooAggregate")))
+            assertEquals(FirstBazEvent::class.java, eventTypeResolver.deserialize(EventTypeDescription("FirstBazEvent", "BazAggregate")))
+            assertEquals(SecondBazEvent::class.java, eventTypeResolver.deserialize(EventTypeDescription("SecondBazEvent", "BazAggregate")))
 
             Assertions.assertThrows(NoSuchElementException::class.java) {
-                eventTypeResolver.deserialize("", "ThirdFooEvent")
+                eventTypeResolver.deserialize(EventTypeDescription("ThirdFooEvent", "FooAggregate"))
             }
         }
     }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/bar/BarAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/bar/BarAggregate.kt
@@ -1,0 +1,8 @@
+package com.cultureamp.developmodule.eventsourcing.bar
+
+import com.cultureamp.eventsourcing.DomainEvent
+
+interface BarAggregate
+sealed interface BarEvent : DomainEvent
+data class FirstBarEvent(val value: String) : BarEvent
+data class SameNameEvent(val value: String) : BarEvent

--- a/src/test/kotlin/com/cultureamp/eventsourcing/baz/BazAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/baz/BazAggregate.kt
@@ -1,0 +1,8 @@
+package com.cultureamp.developmodule.eventsourcing.baz
+
+import com.cultureamp.eventsourcing.DomainEvent
+
+interface BazAggregate
+sealed interface BazEvent : DomainEvent
+data class FirstBazEvent(val value: String) : BazEvent
+data class SecondBazEvent(val value: String) : BazEvent

--- a/src/test/kotlin/com/cultureamp/eventsourcing/foo/FooAggregate.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/foo/FooAggregate.kt
@@ -1,0 +1,8 @@
+package com.cultureamp.developmodule.eventsourcing.foo
+
+import com.cultureamp.eventsourcing.DomainEvent
+
+interface FooAggregate
+sealed interface FooEvent : DomainEvent
+data class FirstFooEvent(val value: String) : FooEvent
+data class SameNameEvent(val value: String) : FooEvent


### PR DESCRIPTION
Also add `PackageRemovingEventTypeResolver` and make it configurable with aggregate types to take advantage of this interface change and allow more efficient querying