### PR TITLE
chore: register kestrel in Backstage catalog [TGI-57]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kestrel
+  description: Kotlin framework for building event-sourced, CQRS services.
+  links:
+    - title: Source
+      url: https://github.com/cultureamp/kestrel
+  tags:
+    - asset-criticality-moderate
+    - camp-performance
+    - data-classification-none
+  annotations:
+    github.com/project-slug: cultureamp/kestrel
+    github.com/team-slug: cultureamp/develop
+    buildkite.com/project-slug: culture-amp/kestrel
+spec:
+  type: library
+  lifecycle: production
+  owner: develop

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     github.com/project-slug: cultureamp/kestrel
     github.com/team-slug: cultureamp/develop
-    buildkite.com/project-slug: culture-amp/kestrel
+    buildkite.com/project-slug: culture-amp/kotlin-eventsourcing
 spec:
   type: library
   lifecycle: production


### PR DESCRIPTION
## Purpose

`kestrel` is the only repo in the Kotlin shared-package set with no `catalog-info.yaml`, so it has no entry in the Backstage software catalog and is invisible to the ownership-sync automation. This adds one.

Groundwork for [TGI-57](https://cultureamp.atlassian.net/browse/TGI-57) (shared-package ownership split), where `kestrel` is slated to move to Insight camp.

## Why the owner says `develop`

Per [Github Teams for repo ownership source-of-truth](https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3046900255), the GitHub team holding the `Team Owners` role is the source of truth and Backstage syncs `catalog-info.yaml` to match it hourly. `develop` currently holds that role on this repo, so this file records the state as it is today — otherwise the sync bot would immediately raise a PR reverting it.

Once the `Team Owners` role is reassigned as part of TGI-57, the bot will raise a follow-up PR updating `spec.owner`, `github.com/team-slug` and the `camp-*` tag automatically.

## Field notes

- `type: library` / `lifecycle: production` — it's a framework consumed by develop-module, career-pathways, manager-lab and survey-conversations-service.
- `data-classification-none` — public repo, processes no data of its own.
- `asset-criticality-moderate` — core framework for several production services, but no live data path of its own.

Happy to adjust any of the tag values if the camp has a stronger view.


[TGI-57]: https://cultureamp.atlassian.net/browse/TGI-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ