### PR TITLE
fix: stop probing Maven Central for plugins on every build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,3 @@
-buildscript {
-    ext.kotlin_version = kotlin_version
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.cinnober.gradle:semver-git:3.0.0")
-        classpath("org.owasp:dependency-check-gradle:12.1.8")
-    }
-}
-
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '2.1.0'


### PR DESCRIPTION
## Summary

Same class of issue as [manager-lab#3535](https://github.com/cultureamp/manager-lab/pull/3535) and [develop-module#4182](https://github.com/cultureamp/develop-module/pull/4182), applied to kestrel's own build. Surfaced by [build 1515](https://buildkite.com/culture-amp/kotlin-eventsourcing/builds/1515), which died in 16s during configuration with `429 Too Many Requests` on all five buildscript/plugin artifacts.

The root `buildscript{}` block declared `mavenCentral()`. Gradle unions those repositories into the same `classpath` configuration that resolves the `plugins{}` block, so **every plugin marker was probed against Maven Central first and fell through to the Gradle Plugin Portal** — 7 wasted lookups on every build. Normally those return a clean 404 and cost only a round-trip; but Maven Central throttles anonymous traffic from shared CI egress IPs, and unlike a 404 a 429 is a hard failure, not a miss to fall through.

This is the same coupling manager-lab#3535 found between root `plugins{}` and root `buildscript{}`.

## Why the whole block goes

Nothing in it was load-bearing:

| Line | Status |
|---|---|
| `classpath("com.cinnober.gradle:semver-git:3.0.0")` | **Dead.** The only reference to `semver` anywhere in the repo is this line — the plugin is never applied. Version comes from `base_version` + `version_suffix` in `gradle.properties`. |
| `classpath("org.owasp:dependency-check-gradle:12.1.8")` | **Redundant.** `plugins { id "org.owasp.dependencycheck" version "12.1.8" }` already puts it on the classpath. |
| `ext.kotlin_version = kotlin_version` | **Self-assignment** of the `gradle.properties` value. The `$kotlin_version` interpolations in `dependencies{}` resolve it as a project property regardless. |

With the block gone, plugin resolution goes through `gradlePluginPortal()` only — which proxies Maven Central for transitive plugin dependencies, so that traffic moves off direct Central too.

## Test plan

Measured locally against an isolated `GRADLE_USER_HOME` (cold dependency cache, `--refresh-dependencies --info`), JDK 17 to match the `gradle:jdk17` CI image:

- [x] **Wasted Maven Central lookups during configuration: 7 → 0.** Before: `semver-git` (.pom, .module), `dependency-check-gradle` (.pom), `kotlin.jvm` marker (.jar), `dependencycheck` marker (.pom), `publish-plugin` (2 × .pom). After: zero requests to `repo.maven.apache.org` at configuration time at all.
- [x] `dependencyCheckAnalyze` still registered — `:dependencyCheckAnalyze (org.owasp.dependencycheck.gradle.tasks.Analyze)`, so the OWASP plugin still loads from `plugins{}` alone.
- [x] `version` still `0.29.0`, `group` still `com.cultureamp` — confirms `semver-git` was never driving versioning.
- [x] `compileKotlin compileTestKotlin javadocJar sourcesJar` → BUILD SUCCESSFUL.

Tests aren't run locally (testcontainers/Postgres); CI covers those.

## Deliberately not in this PR

**The remaining Maven Central usage is legitimate.** kestrel's `repositories{}` serves jackson, exposed, kotest, joda, postgresql, testcontainers, slf4j — all genuinely published to Central. There's nothing to scope away, so the content-filter half of manager-lab#3535 has no analogue here.

**kestrel gets no dependency cache at all between builds.** `bin/docker_gradle` mounts only the source dir and the docker socket into `gradle:jdk17`, so every build resolves the full graph cold against Maven Central — which is why this repo is unusually exposed. Adopting the `cultureamp/maven-cache` plugin (as manager-lab and develop-module have) would mean mounting the plugin's Gradle home / init script and AWS credentials into the container. Worth doing, too big to bundle here.

**`nexus_repository_root` in `gradle.properties` is dead config** — defined, never read, pointing at the old `package-repository.continuous-integration.cultureamp.net` Nexus proxy. Left alone to keep this diff single-purpose; happy to strip it in a follow-up.

Note this PR's own CI can still 429 on the dependency-download phase — that part is unchanged. A retry is expected to clear it.
