### PR TITLE
Bump Exposed to 1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin/
 *.db
 out/
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,41 @@ in its new location.
 The interface for `EventTypeResolver` has changed to support the event-store filtering by `aggregate-type` 
 along side `event-type`. This will only affect codebases that provided a custom implementation of this interface.
 See `PackageRemovingEventTypeResolver` for an example of how to work with the new interface.
+
+# 0.30.0
+
+## Breaking changes
+
+Exposed has been upgraded from `0.49.0` to `1.3.1`. This is a breaking upgrade for consuming
+applications, which will need to make the equivalent changes themselves.
+
+Kestrel is now built with Kotlin `2.2.21`, up from `2.1.0`. Exposed 1.3.1 is published with
+Kotlin 2.3 metadata, and a 2.1 compiler cannot read it (`Module was compiled with an
+incompatible version of Kotlin`); a 2.2 compiler can, since the compiler reads metadata up to
+one minor version ahead. 2.2.21 is therefore the lowest version that can build against Exposed
+1.3.1, chosen so that Kestrel imposes no floor of its own beyond the Kotlin `2.2` that Exposed
+1.3.1 already requires of anything using it.
+
+Anything testing against H2 also needs H2 `2.x`, as Exposed 1.x rejects H2 1.4 at runtime with
+`Unsupported H2 version`.
+
+The stored schema is unchanged, so no data migration is required.
+
+Notable upgrade steps, all of which apply to consuming code too:
+
+- Exposed packages moved from `org.jetbrains.exposed.sql.*` to `org.jetbrains.exposed.v1.*`,
+  split into `org.jetbrains.exposed.v1.core` (tables, columns, expressions) and
+  `org.jetbrains.exposed.v1.jdbc` (`Database`, `SchemaUtils`, `transaction`, statements).
+- `Table.uuid(...)` now maps to `kotlin.uuid.Uuid` rather than `java.util.UUID`. Kestrel's tables
+  use `javaUUID(...)` (from `org.jetbrains.exposed.v1.core.java`) to keep the existing
+  `java.util.UUID` types and the same `uuid` SQL column type.
+- `Table.select { predicate }` is gone: use `selectAll().where { predicate }`. `slice(columns)`
+  is replaced by `select(columns)`, optionally followed by `.where { ... }`.
+- Comparison operators (`eq`, `neq`, `inList`, `greater`, ...) are now top-level functions in
+  `org.jetbrains.exposed.v1.core` rather than `SqlExpressionBuilder` members, and `where { ... }`
+  no longer has `SqlExpressionBuilder` as its receiver. Importing
+  `org.jetbrains.exposed.v1.core.SqlExpressionBuilder.eq` is now a deprecation error.
+
+The one Kestrel API signature this changes is the lock hook: `blockingLockUntilTransactionEnd`
+and `pgAdvisoryXactLock` are now extensions on `JdbcTransaction` rather than `Transaction`,
+because `exec` moved to the JDBC-specific transaction type.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,26 +100,48 @@ events (
 ## Technology Stack
 
 ### Core Technologies
-- **Kotlin 1.9.23** with Java 17 target
-- **PostgreSQL** (production) / **H2** (testing) for event storage
-- **Jetbrains Exposed 0.49.0** - Kotlin SQL DSL for database access
-- **Jackson 2.18.1** - JSON serialization with snake_case naming
+- **Kotlin 2.2.21** with Java 17 target
+- **PostgreSQL** (production) / **H2 2.x** (testing) for event storage
+- **Jetbrains Exposed 1.3.1** - Kotlin SQL DSL for database access
+- **Jackson 3.1.0** - JSON serialization with snake_case naming
 - **Joda-Time** - Date/time handling (not java.time)
 - **Kotest 4.6.2** - Testing framework with assertions
 - **Testcontainers** - PostgreSQL integration testing
 
+Versions live in `gradle.properties` (`kotlin_version`, `exposed_version`, `jackson_version`);
+the rest are declared inline in `build.gradle`.
+
 ### Important Dependencies
 ```kotlin
 // Database
-exposed-core, exposed-jdbc, exposed-jodatime, exposed-json
+exposed-core, exposed-jdbc, exposed-jodatime, exposed-json  // 1.3.1
 postgresql:42.7.3
 
 // Serialization
-jackson-module-kotlin, jackson-datatype-joda
+jackson-module-kotlin, jackson-datatype-joda  // 3.1.0
 
 // Testing
-kotest-runner-junit5-jvm, testcontainers:postgresql
+kotest-runner-junit5-jvm:4.6.2, testcontainers:postgresql:1.19.4, h2:2.3.232
 ```
+
+Two version constraints are coupled and not freely changeable:
+- Exposed 1.3.1 is published with Kotlin 2.3 metadata. Kotlin 2.1 cannot read it; 2.2 can,
+  because the compiler reads metadata up to one minor version ahead. 2.2.21 is the lowest
+  version that builds, chosen so Kestrel imposes no floor beyond the Kotlin 2.2 that Exposed
+  1.3.1 already requires of consumers.
+- Exposed 1.x rejects H2 1.4 at runtime with `Unsupported H2 version`, so tests need H2 2.x.
+
+### Jackson and Exposed package notes
+- Jackson 3 lives under `tools.jackson.*`, **not** `com.fasterxml.jackson.*`.
+- Exposed 1.x lives under `org.jetbrains.exposed.v1.*`, split into `v1.core` (`Table`, `Column`,
+  `ResultRow`, expressions, and the top-level `eq`/`inList`/`greater` operators) and `v1.jdbc`
+  (`Database`, `SchemaUtils`, `transaction`, `JdbcTransaction`, and statements like
+  `insert`/`update`/`upsert`/`selectAll`).
+- Query idioms differ from 0.49: use `selectAll().where { ... }` (there is no `select { predicate }`)
+  and `select(columns).where { ... }` (there is no `slice(...)`). `where { }` does **not** have
+  `SqlExpressionBuilder` as its receiver.
+- Use `javaUUID("col")` for `java.util.UUID` columns. Plain `uuid(...)` now maps to
+  `kotlin.uuid.Uuid`, which would change the column's Kotlin type.
 
 ## Development Patterns
 
@@ -194,7 +216,7 @@ asyncProcessor.start(ExponentialBackoff())
 - Advisory locks ensure bookmark coordination across processor instances
 - 500ms delay between automatic retries
 
-### Current Development Context
-- Main branch: `master`
-- Current branch: `wb/sequence_number_for_event_processors`
-- Recent work focuses on table lock timeout configuration and event type filtering
+### Repository Context
+- Main branch: `master` (PRs target this)
+- Check `git log` and `CHANGELOG.md` for recent work rather than relying on notes here,
+  which go stale quickly.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
+    id 'org.jetbrains.kotlin.jvm' version '2.2.21'
     id 'maven-publish'
     id 'signing'
     id "org.owasp.dependencycheck" version "12.1.8"
@@ -157,7 +157,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "io.kotest:kotest-runner-junit5-jvm:4.6.2" // for kotest framework
     testImplementation "io.kotest:kotest-assertions-core-jvm:4.6.2" // for kotest core jvm assertions
-    testImplementation "com.h2database:h2:1.4.200"
+    testImplementation "com.h2database:h2:2.3.232" // Exposed 1.x requires H2 2.x
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
     implementation "joda-time:joda-time:2.10.10"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
-base_version=0.29.0
+base_version=0.30.0
 group_id=com.cultureamp
 version_suffix=
 
 targetJvmVersion=17
 
 nexus_repository_root=https://package-repository.continuous-integration.cultureamp.net/repository/maven-
-exposed_version=0.49.0
-kotlin_version=2.1.0
+exposed_version=1.3.1
+kotlin_version=2.2.21
 jackson_version=3.1.0
 
 signing.gnupg.executable=gpg

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
@@ -1,9 +1,10 @@
 package com.cultureamp.eventsourcing
 
-import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.jodatime.datetime
-import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.core.*
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jodatime.datetime
 import org.joda.time.DateTime
 import java.io.Closeable
 import java.sql.Connection
@@ -64,7 +65,7 @@ class RelationalDatabaseBookmarkStore(
         }
     }
 
-    private fun rowsForBookmarks(bookmarkNames: Set<String>) = table.select { table.name.inList(bookmarkNames) }
+    private fun rowsForBookmarks(bookmarkNames: Set<String>) = table.selectAll().where { table.name.inList(bookmarkNames) }
     private fun isExists(bookmarkName: String) = !rowsForBookmarks(setOf(bookmarkName)).empty()
 }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EventsSequenceStats.kt
@@ -1,13 +1,14 @@
 package com.cultureamp.eventsourcing
 
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.Op
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.max
-import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.upsert
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.max
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.upsert
 import kotlin.reflect.KClass
 
 val defaultEventsSequenceStatsTableName = "events_sequence_stats"
@@ -41,8 +42,8 @@ class RelationalDatabaseEventsSequenceStats(
     override fun lastSequence(eventClasses: List<KClass<out DomainEvent>>): Long = transaction(db) {
         val maxSequence = table.sequence.max()
         table
-            .slice(maxSequence)
-            .select {
+            .select(maxSequence)
+            .where {
                 if (eventClasses.isNotEmpty()) {
                     val eventTypeDefinitions = eventClasses.map { eventTypeResolver.serialize(it.java) }
                     val eventTypes = eventTypeDefinitions.eventTypes()

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStore.kt
@@ -1,20 +1,24 @@
 package com.cultureamp.eventsourcing
 
-import org.jetbrains.exposed.exceptions.ExposedSQLException
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.Op
-import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.Transaction
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.jodatime.datetime
-import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.vendors.H2Dialect
-import org.jetbrains.exposed.sql.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.core.vendors.H2Dialect
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jodatime.datetime
 import tools.jackson.core.JacksonException
 import tools.jackson.databind.ObjectMapper
 import tools.jackson.databind.PropertyNamingStrategies
@@ -43,7 +47,7 @@ class RelationalDatabaseEventStore<M : EventMetadata>(
     private val metadataClass: Class<M>,
     private val objectMapper: ObjectMapper,
     private val eventTypeResolver: EventTypeResolver,
-    private val blockingLockUntilTransactionEnd: Transaction.() -> CommandError? = { null },
+    private val blockingLockUntilTransactionEnd: JdbcTransaction.() -> CommandError? = { null },
     private val afterSinkHook: (List<SequencedEvent<M>>) -> Unit = { },
     private val eventsSinkTable: Events = events,
 ) : EventStore<M> {
@@ -57,7 +61,7 @@ class RelationalDatabaseEventStore<M : EventMetadata>(
             eventTypeResolver: EventTypeResolver = defaultEventTypeResolver,
             eventsSequenceStats: EventsSequenceStats? = RelationalDatabaseEventsSequenceStats(db, eventTypeResolver, defaultEventsSequenceStatsTableName).also { it.createSchemaIfNotExists() },
             lockTimeoutMs: Int = 10_000,
-            noinline blockingLockUntilTransactionEnd: Transaction.() -> CommandError? = {
+            noinline blockingLockUntilTransactionEnd: JdbcTransaction.() -> CommandError? = {
                 when (db.dialect) {
                     is H2Dialect -> null
                     is PostgreSQLDialect -> pgAdvisoryXactLock(lockTimeoutMs)
@@ -163,7 +167,8 @@ class RelationalDatabaseEventStore<M : EventMetadata>(
     override fun getAfter(sequence: Long, eventClasses: List<KClass<out DomainEvent>>, batchSize: Int): List<SequencedEvent<M>> {
         return transaction(db) {
             events
-                .select {
+                .selectAll()
+                .where {
                     val eventTypeMatches = if (eventClasses.isNotEmpty()) {
                         val eventTypeDefinitions = eventClasses.map { eventTypeResolver.serialize(it.java) }
                         val eventTypes = eventTypeDefinitions.eventTypes()
@@ -185,7 +190,8 @@ class RelationalDatabaseEventStore<M : EventMetadata>(
     override fun eventsFor(aggregateId: UUID): List<Event<M>> {
         return transaction(db) {
             events
-                .select { events.aggregateId eq aggregateId }
+                .selectAll()
+                .where { events.aggregateId eq aggregateId }
                 .orderBy(events.sequence)
                 .map(::rowToSequencedEvent)
                 .map { it.event }
@@ -205,9 +211,9 @@ internal fun <T> String.asClass(): Class<out T>? {
 class Events(tableName: String = defaultEventsTableName, jsonb: Table.(String) -> Column<String> = Table::jsonb) :
     Table(tableName) {
     val sequence = long("sequence").autoIncrement()
-    val eventId = uuid("id")
+    val eventId = javaUUID("id")
     val aggregateSequence = long("aggregate_sequence")
-    val aggregateId = uuid("aggregate_id")
+    val aggregateId = javaUUID("aggregate_id")
     val aggregateType = varchar("aggregate_type", 128)
     val eventType = varchar("event_type", 256)
     val createdAt = datetime("created_at")
@@ -227,7 +233,7 @@ private fun Table.nonUniqueIndex(vararg columns: Column<*>) = index(false, *colu
 object ConcurrencyError : RetriableError
 object LockingError : CommandError
 
-fun Transaction.pgAdvisoryXactLock(lockTimeoutMs: Int = 10_000): CommandError? {
+fun JdbcTransaction.pgAdvisoryXactLock(lockTimeoutMs: Int = 10_000): CommandError? {
     if (lockTimeoutMs == 0) {
         // Non-blocking
         val gotLock = exec("SELECT pg_try_advisory_xact_lock(-1)") { rs ->

--- a/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/jsonb.kt
@@ -1,9 +1,9 @@
 package com.cultureamp.eventsourcing
 
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.StringColumnType
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.statements.api.PreparedStatementApi
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.StringColumnType
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.api.PreparedStatementApi
 import org.postgresql.util.PGobject
 
 fun Table.jsonb(name: String): Column<String> =
@@ -17,13 +17,13 @@ private class Jsonb : StringColumnType() {
             val pgObject = PGobject()
             pgObject.type = "jsonb"
             pgObject.value = value
-            stmt[index] = pgObject
+            stmt.set(index, pgObject, this)
         } else {
-            stmt[index] = value!!
+            stmt.set(index, value!!, this)
         }
     }
 
-    override fun valueFromDB(value: Any): Any {
+    override fun valueFromDB(value: Any): String {
         return if (value is PGobject) {
             value.value!!
         } else {

--- a/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
+++ b/src/main/kotlin/com/cultureamp/script/DemonstrateEventSequenceIdGaps.kt
@@ -16,8 +16,8 @@ import com.cultureamp.eventsourcing.SimpleAggregate
 import com.cultureamp.eventsourcing.SimpleAggregateConstructor
 import com.cultureamp.eventsourcing.UpdateCommand
 import com.cultureamp.eventsourcing.UpdateEvent
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.lang.RuntimeException
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitorIntegrationTest.kt
@@ -10,12 +10,11 @@ import com.cultureamp.eventsourcing.example.SurveyNamesCommandProjector
 import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.StdOutSqlLogger
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.addLogger
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.core.StdOutSqlLogger
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.joda.time.DateTime
 import java.util.UUID
 

--- a/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/CommandGatewayIntegrationTest.kt
@@ -53,11 +53,11 @@ import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.joda.time.DateTime
 import java.util.UUID
 import com.cultureamp.eventsourcing.example.Created as SurveyCreated

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventConsumerStatisticsTest.kt
@@ -20,9 +20,9 @@ import io.kotest.assertions.fail
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.joda.time.DateTime
 import java.util.UUID
 import kotlin.reflect.KClass

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EventsSequenceStatsTest.kt
@@ -6,7 +6,7 @@ import com.cultureamp.eventsourcing.example.Renamed
 import com.cultureamp.eventsourcing.example.Restored
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 import org.testcontainers.containers.PostgreSQLContainer
 import kotlin.reflect.KClass
 

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PgTestConfig.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PgTestConfig.kt
@@ -1,6 +1,6 @@
 package com.cultureamp.eventsourcing
 
-import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.v1.jdbc.Database
 
 // H2 is the default database. To use this, you need to input your database details
 object PgTestConfig {

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseBookmarkStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseBookmarkStoreTest.kt
@@ -2,9 +2,9 @@ package com.cultureamp.eventsourcing
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 class RelationalDatabaseBookmarkStoreTest : DescribeSpec({
     val db = PgTestConfig.db ?: Database.connect(url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEventStoreTest.kt
@@ -13,10 +13,10 @@ import com.cultureamp.eventsourcing.sample.StandardEventMetadata
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.joda.time.DateTime
 import java.util.UUID
 

--- a/src/test/kotlin/com/cultureamp/eventsourcing/UpcastTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/UpcastTest.kt
@@ -5,12 +5,11 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.StdOutSqlLogger
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.addLogger
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.core.StdOutSqlLogger
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.joda.time.DateTime
 import java.lang.RuntimeException
 import java.util.*

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/ParticipantProjector.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/ParticipantProjector.kt
@@ -3,10 +3,11 @@ package com.cultureamp.eventsourcing.example
 import com.cultureamp.eventsourcing.DomainEventProcessor
 import com.cultureamp.eventsourcing.example.ParticipantTable.invitationId
 import com.cultureamp.eventsourcing.example.ParticipantTable.invitedAt
-import org.jetbrains.exposed.sql.*
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.jodatime.datetime
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.core.*
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.jdbc.*
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jodatime.datetime
 import java.util.*
 
 
@@ -30,7 +31,7 @@ class ParticipantProjector(private val database: Database): DomainEventProcessor
     }
 
     fun isInvited(invitationId: UUID): Boolean = transaction(database) {
-        ParticipantTable.select { (ParticipantTable.invitationId eq invitationId) and (ParticipantTable.invitedAt neq null) }.firstOrNull() != null
+        ParticipantTable.selectAll().where { (ParticipantTable.invitationId eq invitationId) and (ParticipantTable.invitedAt neq null) }.firstOrNull() != null
     }
 
     init {
@@ -42,9 +43,9 @@ class ParticipantProjector(private val database: Database): DomainEventProcessor
 }
 
 object ParticipantTable : Table() {
-    val invitationId = uuid("invitation_id")
-    val surveyPeriodId = uuid("account_id")
-    val employeeId = uuid("employee_id")
+    val invitationId = javaUUID("invitation_id")
+    val surveyPeriodId = javaUUID("account_id")
+    val employeeId = javaUUID("employee_id")
     val invitedAt = datetime("invited_at").nullable()
     override val primaryKey = PrimaryKey(invitationId)
 }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyNamesCommandProjector.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyNamesCommandProjector.kt
@@ -1,14 +1,15 @@
 package com.cultureamp.eventsourcing.example
 
 import com.cultureamp.eventsourcing.DomainEventProcessor
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.Table
-import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
-import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.update
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
 import java.util.*
 
 class SurveyNamesCommandProjector(private val database: Database) : DomainEventProcessor<SurveyEvent> {
@@ -44,8 +45,8 @@ class SurveyNamesCommandProjector(private val database: Database) : DomainEventP
 }
 
 object SurveyNames : Table() {
-    val surveyId = uuid("survey_id")
-    val accountId = uuid("account_id")
+    val surveyId = javaUUID("survey_id")
+    val accountId = javaUUID("account_id")
     val locale = enumerationByName("locale", 10, Locale::class)
     val name = text("name").index()
 }

--- a/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyNamesQuery.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/example/SurveyNamesQuery.kt
@@ -1,9 +1,10 @@
 package com.cultureamp.eventsourcing.example
 
-import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.select
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.util.*
 
 interface SurveyNamesQuery  {
@@ -16,6 +17,6 @@ object SurveyNameAlwaysAvailable : SurveyNamesQuery {
 
 class RelationalDatabaseSurveyNamesQuery internal constructor(private val database: Database) : SurveyNamesQuery {
     override fun nameExistsFor(accountId: UUID, name: String, locale: Locale) = transaction(database) {
-        SurveyNames.select { (SurveyNames.name eq name) and (SurveyNames.locale eq locale) }.any()
+        SurveyNames.selectAll().where { (SurveyNames.name eq name) and (SurveyNames.locale eq locale) }.any()
     }
 }


### PR DESCRIPTION
Bump Exposed from `0.49.0` to `1.3.1` and Kotlin `2.1.0` → `2.2.21`

Downstream consumers are ahead, and we're lagging considerably, so let's catch up