### PR TITLE
Publish to Maven Central automatically on version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,37 +64,39 @@ jobs:
 
           skip() { echo "::notice::$1"; echo "should_release=false" >> "$GITHUB_OUTPUT"; exit 0; }
 
-          # A version already on Maven Central can never be re-published, so this check comes
-          # first: it makes the workflow safe to add to a repo whose current version is released,
-          # and safe to re-run after a partial failure.
+          # Did this push bump the version? This is the trigger, and it is answered entirely
+          # from the local clone, so the common case - a push that changes anything other than
+          # the version - costs nothing and contacts no external service.
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::Forced release requested; skipping the version-bump check."
+          else
+            # `github.event.before` is master's previous tip, which beats HEAD^ when a push
+            # contains several commits. Fall back to the first parent when it is unavailable
+            # (workflow_dispatch, a freshly-created branch, or a rewritten history).
+            previous_ref="HEAD^"
+            if [[ -n "$BEFORE" && ! "$BEFORE" =~ ^0+$ ]] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+              previous_ref="$BEFORE"
+            fi
+
+            previous_version="$(git show "$previous_ref:gradle.properties" 2>/dev/null | read_base_version || true)"
+            echo "Previous base_version ($previous_ref): ${previous_version:-<unknown>}"
+            echo "Current  base_version (HEAD): $version"
+
+            if [ "$previous_version" = "$version" ]; then
+              skip "base_version unchanged at $version; nothing to release."
+            fi
+          fi
+
+          # Everything below guards the publish itself, so it applies to forced releases too:
+          # a version on Maven Central can never be re-published, whatever triggered the run.
+          # Cheapest check first again - the tag is local, Maven Central is not.
+          if [ -n "$(git tag -l "v$version")" ]; then
+            skip "Tag v$version already exists; $version has already been released."
+          fi
+
           pom="https://repo1.maven.org/maven2/com/cultureamp/kestrel/$version/kestrel-$version.pom"
           if curl -sfI --retry 3 "$pom" > /dev/null; then
             skip "$version is already published to Maven Central. Bump base_version in gradle.properties to release."
-          fi
-
-          if [ -n "$(git tag -l "v$version")" ]; then
-            skip "Tag v$version already exists. Bump base_version in gradle.properties to release."
-          fi
-
-          if [ "$FORCE" = "true" ]; then
-            echo "::notice::Forced release of $version."
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # `github.event.before` is master's previous tip. Fall back to the first parent when
-          # it is unavailable (workflow_dispatch, a freshly-created branch, or a rewritten history).
-          previous_ref="HEAD^"
-          if [[ -n "$BEFORE" && ! "$BEFORE" =~ ^0+$ ]] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
-            previous_ref="$BEFORE"
-          fi
-
-          previous_version="$(git show "$previous_ref:gradle.properties" 2>/dev/null | read_base_version || true)"
-          echo "Previous base_version ($previous_ref): ${previous_version:-<unknown>}"
-          echo "Current  base_version (HEAD): $version"
-
-          if [ "$previous_version" = "$version" ]; then
-            skip "base_version unchanged at $version; nothing to release."
           fi
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,8 +104,8 @@ jobs:
     needs: detect
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
-    # Gate the credentials behind a GitHub Environment, so they can be given required
-    # reviewers and restricted to master independently of this file.
+    # Gate the credentials behind a GitHub Environment whose deployment branch rule is limited
+    # to master, so they cannot be read by a job on any other branch.
     environment: maven-central
     permissions:
       contents: write # push the release tag and create the GitHub release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,6 +126,68 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
+      # Runs before the build so an expired key costs seconds, not a full test suite. Expiry is
+      # a property of the key's self-signature, so it can be extended without generating a new
+      # key - the messages below say how, because nobody will remember in two years.
+      - name: Check the signing key
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          REPO: ${{ github.repository }}
+          WARN_WITHIN_DAYS: "90"
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GPG_SIGNING_KEY:-}" ]; then
+            echo "::error::GPG_SIGNING_KEY is not set on the maven-central environment. Run bin/setup_release_secrets - see CONTRIBUTING.md."
+            exit 1
+          fi
+
+          # Throwaway keyring. Importing needs no passphrase, and nothing outlives this step.
+          GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; chmod 700 "$GNUPGHOME"
+          trap 'rm -rf "$GNUPGHOME"' EXIT
+
+          printf '%s' "$GPG_SIGNING_KEY" | gpg --batch --quiet --import 2>/dev/null || true
+
+          # List *secret* keys, not all keys: a public key imports perfectly happily, so this is
+          # what catches the easy mistake of exporting with --export instead of
+          # --export-secret-keys. The sec record carries the expiry in the same field.
+          read -r keyid expiry < <(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ { print $5, $7; exit }')
+
+          if [ -z "${keyid:-}" ]; then
+            echo "::error::GPG_SIGNING_KEY does not contain a private key. It is either truncated, or it holds only a public key - the value must come from 'gpg --armor --export-secret-keys <keyid>', not 'gpg --armor --export'. Re-run bin/setup_release_secrets to fix it."
+            exit 1
+          fi
+
+          if [ -z "${expiry:-}" ] || [ "$expiry" = "0" ]; then
+            echo "Signing key $keyid does not expire."
+            exit 0
+          fi
+
+          # GNU date on the runner, BSD date if anyone runs this by hand on a Mac.
+          on="$(date -u -d "@$expiry" +%Y-%m-%d 2>/dev/null || date -u -r "$expiry" +%Y-%m-%d)"
+          now="$(date +%s)"
+          # `days` is for display only. Integer division truncates toward zero, so a key that
+          # lapsed an hour ago also reports 0 - the expired test below compares timestamps.
+          days=$(( (expiry - now) / 86400 ))
+
+          # GitHub annotations are single-line; %0A is how you get a line break into one.
+          remedy="Extend it - this does NOT need a new key, and the key id, fingerprint and identity all stay the same:%0A"
+          remedy+="  gpg --edit-key $keyid     # then type: expire, pick a new period, then save%0A"
+          remedy+="  gpg --keyserver keys.openpgp.org --send-keys $keyid%0A"
+          remedy+="  gpg --armor --export-secret-keys $keyid | gh secret set GPG_SIGNING_KEY --repo $REPO --env maven-central%0A"
+          remedy+="The passphrase is in 1Password (Team Develop). See CONTRIBUTING.md."
+
+          if [ "$expiry" -le "$now" ]; then
+            echo "::error::Signing key $keyid EXPIRED on $on. Maven Central rejects artifacts signed with an expired key, so this release is stopping here rather than publishing something nobody can verify. Nothing has been published, and re-running this workflow once the key is fixed will pick up where it left off.%0A%0A$remedy"
+            exit 1
+          fi
+
+          if [ "$days" -le "$WARN_WITHIN_DAYS" ]; then
+            echo "::warning::Signing key $keyid expires on $on - only $days days away. Once it lapses, every release will fail until it is extended. Doing it now takes about five minutes.%0A%0A$remedy"
+          fi
+
+          echo "Signing key $keyid expires $on ($days days away)."
+
       # Re-run the tests here rather than trusting the PR build: publishing is irreversible,
       # so the gate belongs immediately before it.
       - name: Build and test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,172 @@
+name: Release
+
+# Publishes to Maven Central when `base_version` in gradle.properties increases on master.
+#
+# Merging a PR that bumps `base_version` is the release trigger: no manual step, no
+# separately-maintained version file. Pushes that don't change the version are a no-op.
+#
+# Required repository secrets (Settings > Secrets and variables > Actions):
+#   CENTRAL_TOKEN_USERNAME    Sonatype Central Portal token username  (1Password: Team Develop > Kestrel Sonatype Credentials)
+#   CENTRAL_TOKEN_PASSWORD    Sonatype Central Portal token password
+#   GPG_SIGNING_KEY           ASCII-armoured private key: gpg --armor --export-secret-keys <keyid>
+#   GPG_SIGNING_PASSPHRASE    Passphrase for that key
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Release the current base_version even if this commit didn't bump it. Still refuses to overwrite an already-published version."
+        type: boolean
+        default: false
+
+# One release at a time. Never cancel one in flight: publishing to Maven Central is not
+# reversible, so a half-finished run must be allowed to finish rather than be killed.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# Least privilege by default. The release job re-grants contents:write for the tag it pushes.
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: check
+        env:
+          BEFORE: ${{ github.event.before }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          read_base_version() { sed -n 's/^base_version=//p' | tr -d '[:space:]'; }
+
+          version="$(read_base_version < gradle.properties)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::base_version '$version' is not a plain x.y.z version; refusing to release."
+            exit 1
+          fi
+
+          skip() { echo "::notice::$1"; echo "should_release=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # A version already on Maven Central can never be re-published, so this check comes
+          # first: it makes the workflow safe to add to a repo whose current version is released,
+          # and safe to re-run after a partial failure.
+          pom="https://repo1.maven.org/maven2/com/cultureamp/kestrel/$version/kestrel-$version.pom"
+          if curl -sfI --retry 3 "$pom" > /dev/null; then
+            skip "$version is already published to Maven Central. Bump base_version in gradle.properties to release."
+          fi
+
+          if [ -n "$(git tag -l "v$version")" ]; then
+            skip "Tag v$version already exists. Bump base_version in gradle.properties to release."
+          fi
+
+          if [ "$FORCE" = "true" ]; then
+            echo "::notice::Forced release of $version."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # `github.event.before` is master's previous tip. Fall back to the first parent when
+          # it is unavailable (workflow_dispatch, a freshly-created branch, or a rewritten history).
+          previous_ref="HEAD^"
+          if [[ -n "$BEFORE" && ! "$BEFORE" =~ ^0+$ ]] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            previous_ref="$BEFORE"
+          fi
+
+          previous_version="$(git show "$previous_ref:gradle.properties" 2>/dev/null | read_base_version || true)"
+          echo "Previous base_version ($previous_ref): ${previous_version:-<unknown>}"
+          echo "Current  base_version (HEAD): $version"
+
+          if [ "$previous_version" = "$version" ]; then
+            skip "base_version unchanged at $version; nothing to release."
+          fi
+
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Publish ${{ needs.detect.outputs.version }}
+    needs: detect
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    # Gate the credentials behind a GitHub Environment, so they can be given required
+    # reviewers and restricted to master independently of this file.
+    environment: maven-central
+    permissions:
+      contents: write # push the release tag and create the GitHub release
+    env:
+      VERSION: ${{ needs.detect.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      # Re-run the tests here rather than trusting the PR build: publishing is irreversible,
+      # so the gate belongs immediately before it.
+      - name: Build and test
+        run: ./gradlew build
+
+      - name: Publish to Maven Central
+        env:
+          CENTRAL_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          CENTRAL_TOKEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+      - name: Tag and create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+
+          # CHANGELOG.md sections are `# <version>` headings, and only releases with breaking
+          # changes get one, so an empty extract is normal.
+          notes="$(awk -v heading="# $VERSION" '
+            $0 == heading { found = 1; next }
+            found && /^# / { exit }
+            found { print }
+          ' CHANGELOG.md)"
+
+          if [ -z "${notes//[[:space:]]/}" ]; then
+            notes="See the commit history for the changes in this release."
+          fi
+
+          gh release create "v$VERSION" --title "$VERSION" --notes "$notes"
+
+      - name: Summary
+        run: |
+          {
+            echo "Published \`com.cultureamp:kestrel:$VERSION\` to Maven Central."
+            echo
+            echo "It usually appears within 15-30 minutes at"
+            echo "<https://central.sonatype.com/artifact/com.cultureamp/kestrel/$VERSION>."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,14 +27,18 @@ Kestrel is a Kotlin framework for building event-sourced, CQRS applications. It 
 ```
 
 ### Publishing
+Releases are automatic: bumping `base_version` in `gradle.properties` and merging to `master` makes
+`.github/workflows/release.yaml` publish to Maven Central, tag `v<version>` and cut a GitHub release.
+See CONTRIBUTING.md.
+
 ```bash
 # Local development (no GPG signing required)
 SKIP_SIGNING=true ./gradlew publishToMavenLocal
 
-# Production release (requires GPG key and Sonatype credentials)
-export SONATYPE_USERNAME=<username>
-export SONATYPE_PASSWORD=<password>
-./gradlew clean build publish
+# Manual release, only needed if the workflow is unavailable
+export CENTRAL_TOKEN_USERNAME=<username>
+export CENTRAL_TOKEN_PASSWORD=<password>
+./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
 ```
 
 ### Security and CI
@@ -178,12 +182,15 @@ asyncProcessor.start(ExponentialBackoff())
 ## Configuration Management
 
 ### Version Management
-- Update `base_version` in `gradle.properties` for releases
+- Update `base_version` in `gradle.properties` for releases - this bump is the release trigger
 - Follow semantic versioning
-- Update CHANGELOG.md for breaking changes
+- Update CHANGELOG.md for breaking changes, under a `# <version>` heading, which the release
+  workflow uses as the GitHub release notes
 
 ### Environment Variables
-- `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` - Maven Central publishing
+- `CENTRAL_TOKEN_USERNAME` / `CENTRAL_TOKEN_PASSWORD` - Sonatype Central Portal publishing
+- `GPG_SIGNING_KEY` / `GPG_SIGNING_PASSPHRASE` - armoured signing key, used by CI; when unset the
+  build falls back to the local gpg agent via `useGpgCmd()`
 - `SKIP_SIGNING=true` - Bypass GPG signing for local development
 
 ## Testing Strategy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ To compile and run tests
 
 `./gradlew test`
 
-Make sure to increase the `base_version` number in `gradle.properties`
+Make sure to increase the `base_version` number in `gradle.properties`. That bump is what triggers a
+release when your PR is merged - see [Releasing](#releasing).
 
 ### Publishing to maven local
 
@@ -17,8 +18,64 @@ If you need to test your version with another project in your development enviro
 
 `SKIP_SIGNING=true ./gradlew publishToMavenLocal`
 
-## Publishing
-If you're authorized to publish to Maven Central, which is a process done manually by a developer, you'll need access to the Central Portal credentials (details below).
+## Releasing
+
+Releases are automatic. The `.github/workflows/release.yaml` workflow watches pushes to `master`, and when
+`base_version` in `gradle.properties` has increased it builds, tests, signs and publishes the artefacts to
+Maven Central, then tags the commit `v<version>` and creates a GitHub release.
+
+So to cut a release:
+
+1. Bump `base_version` in `gradle.properties` (semantic versioning).
+2. Add a `# <version>` section to `CHANGELOG.md` if there are breaking changes. The workflow uses that section
+   as the GitHub release notes.
+3. Merge to `master`. If the `maven-central` environment has required reviewers configured, the
+   release job waits for an approval before it can touch the publishing credentials.
+
+The artefacts typically appear on Maven Central within 15-30 minutes. A push that doesn't change
+`base_version` is a no-op, and a version already present on Maven Central is never re-published, so the
+workflow is safe to re-run.
+
+You can verify publication at:
+- **Central Portal**: https://central.sonatype.com/artifact/com.cultureamp/kestrel
+- **Maven Central Search**: https://search.maven.org/artifact/com.cultureamp/kestrel
+
+### Secrets and access control
+
+Kestrel is a **public** repository, and these credentials can publish signed artefacts under
+`com.cultureamp` to an immutable registry. Treat them accordingly.
+
+The release job needs four secrets, ideally attached to a `maven-central` GitHub Environment
+rather than to the repository, so they can be gated. Values come from 1Password,
+Team Develop > Kestrel Sonatype Credentials.
+
+| Secret | Value |
+| --- | --- |
+| `CENTRAL_TOKEN_USERNAME` | Central Portal token username |
+| `CENTRAL_TOKEN_PASSWORD` | Central Portal token password |
+| `GPG_SIGNING_KEY` | ASCII-armoured private key: `gpg --armor --export-secret-keys <keyid>` |
+| `GPG_SIGNING_PASSPHRASE` | Passphrase for that key |
+
+The signing key must be published to a keyserver for Maven Central to accept it - see
+[GPG Key](#3-gpg-key) below. A leaked Central Portal token can simply be regenerated; a leaked
+signing key has to be revoked on the keyservers and replaced, so it is the more sensitive of the two.
+
+Two controls do the real work here, and neither lives in the workflow file:
+
+- **Branch protection on `master` requiring review.** The release job only ever runs on merged
+  code, and GitHub never gives secrets to a pull request from a fork, so outsiders cannot reach
+  these credentials. Anyone who can merge to `master`, however, can write a workflow step that
+  exfiltrates them - so merge review *is* the security boundary.
+- **Required reviewers on the `maven-central` environment**, restricted to the `master` branch.
+  This adds a human approval between a merge and the credentials being decrypted.
+
+The workflow itself runs with `permissions: contents: read` by default, grants `contents: write`
+only to the release job for the tag it pushes, and pins every third-party action to a commit SHA.
+
+## Publishing manually
+
+You shouldn't normally need this; it's here for when the workflow is unavailable. If you're publishing to
+Maven Central by hand you'll need access to the Central Portal credentials (details below).
 
 **Note: Sonatype has migrated from OSSRH to Central Portal. The old OSSRH system is deprecated.**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,31 @@ You can verify publication at:
 - **Central Portal**: https://central.sonatype.com/artifact/com.cultureamp/kestrel
 - **Maven Central Search**: https://search.maven.org/artifact/com.cultureamp/kestrel
 
+### First-time setup
+
+Run this once, from a repo admin account:
+
+```bash
+bin/setup_release_secrets --dry-run   # check everything, change nothing
+bin/setup_release_secrets             # apply
+```
+
+It creates the `maven-central` environment, restricts it to `master`, loads the four secrets,
+publishes your signing key to a keyserver, requires a reviewed pull request on `master`, and
+finishes with a test signature through the same code path CI uses. Secret values are never
+printed and never written to disk. It is safe to re-run.
+
+By default it signs with the key named by `signing.gnupg.keyName` in `~/.gradle/gradle.properties`.
+Prefer a key that isn't tied to one person:
+
+```bash
+bin/setup_release_secrets --new-key your-team-alias@cultureamp.com
+```
+
+That generates a dedicated release-signing key, so releases don't depend on one engineer's
+personal key remaining valid and a leak doesn't force anyone to revoke their own identity key.
+Save the passphrase in 1Password before you run it - it cannot be recovered.
+
 ### Secrets and access control
 
 Kestrel is a **public** repository, and these credentials can publish signed artefacts under

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,13 @@ By default it signs with the key named by `signing.gnupg.keyName` in `~/.gradle/
 Prefer a key that isn't tied to one person:
 
 ```bash
-bin/setup_release_secrets --new-key your-team-alias@cultureamp.com
+bin/setup_release_secrets --new-key team_pathfinder@cultureamp.com
 ```
 
-That generates a dedicated release-signing key, so releases don't depend on one engineer's
-personal key remaining valid and a leak doesn't force anyone to revoke their own identity key.
-Save the passphrase in 1Password before you run it - it cannot be recovered.
+That generates a dedicated release-signing key owned by the team (`team_pathfinder@cultureamp.com`),
+so releases don't depend on one engineer's personal key remaining valid and a leak doesn't force
+anyone to revoke their own identity key. Save the passphrase in 1Password before you run it - it
+cannot be recovered.
 
 ### Secrets and access control
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,7 @@ So to cut a release:
 1. Bump `base_version` in `gradle.properties` (semantic versioning).
 2. Add a `# <version>` section to `CHANGELOG.md` if there are breaking changes. The workflow uses that section
    as the GitHub release notes.
-3. Merge to `master`. If the `maven-central` environment has required reviewers configured, the
-   release job waits for an approval before it can touch the publishing credentials.
+3. Merge to `master`.
 
 The artefacts typically appear on Maven Central within 15-30 minutes. A push that doesn't change
 `base_version` is a no-op, and a version already present on Maven Central is never re-published, so the
@@ -45,9 +44,9 @@ You can verify publication at:
 Kestrel is a **public** repository, and these credentials can publish signed artefacts under
 `com.cultureamp` to an immutable registry. Treat them accordingly.
 
-The release job needs four secrets, ideally attached to a `maven-central` GitHub Environment
-rather than to the repository, so they can be gated. Values come from 1Password,
-Team Develop > Kestrel Sonatype Credentials.
+The release job needs four secrets, attached to the `maven-central` GitHub Environment rather than
+to the repository, so they can only be read by a job running on `master`. Values come from
+1Password, Team Develop > Kestrel Sonatype Credentials.
 
 | Secret | Value |
 | --- | --- |
@@ -62,12 +61,18 @@ signing key has to be revoked on the keyservers and replaced, so it is the more 
 
 Two controls do the real work here, and neither lives in the workflow file:
 
-- **Branch protection on `master` requiring review.** The release job only ever runs on merged
-  code, and GitHub never gives secrets to a pull request from a fork, so outsiders cannot reach
-  these credentials. Anyone who can merge to `master`, however, can write a workflow step that
-  exfiltrates them - so merge review *is* the security boundary.
-- **Required reviewers on the `maven-central` environment**, restricted to the `master` branch.
-  This adds a human approval between a merge and the credentials being decrypted.
+- **Branch protection on `master`**, requiring a pull request with an approving review. The release
+  job only ever runs on merged code, and GitHub never gives secrets to a pull request from a fork,
+  so outsiders cannot reach these credentials. Anyone who can merge to `master`, however, can write
+  a workflow step that exfiltrates them - so merge review *is* the security boundary. Merging is
+  restricted to write access, so only Culture Ampers can trigger a release.
+- **A deployment branch rule on the `maven-central` environment limited to `master`**, so the
+  secrets cannot be read by a job on any other branch even if a future workflow references the
+  environment.
+
+Required reviewers on the environment are deliberately *not* used: the pull request review is
+already an approval of the same change by the same people, so a second gate would only delay
+releases.
 
 The workflow itself runs with `permissions: contents: read` by default, grants `contents: write`
 only to the release job for the tag it pushes, and pins every third-party action to a commit SHA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,25 @@ releases.
 The workflow itself runs with `permissions: contents: read` by default, grants `contents: write`
 only to the release job for the tag it pushes, and pins every third-party action to a commit SHA.
 
+### Signing key expiry
+
+The release-signing key expires - two years by default, which satisfies the Secrets standard's
+"shortest reasonable lifetime" without making the key a permanent liability. Every release checks
+it: inside the last 90 days you get a warning annotation, and once it has lapsed the release fails
+*before* publishing anything, with the fix printed in the log.
+
+Extending is not the same as rotating, and is all that's needed. The key id, fingerprint and
+identity all stay the same, so nothing downstream is affected and old signatures keep verifying:
+
+```bash
+gpg --edit-key <keyid>          # then: expire, choose a new period, save
+gpg --keyserver keys.openpgp.org --send-keys <keyid>
+gpg --armor --export-secret-keys <keyid> \
+  | gh secret set GPG_SIGNING_KEY --repo cultureamp/kestrel --env maven-central
+```
+
+The last step is needed because the exported block carries the updated self-signature.
+
 ## Publishing manually
 
 You shouldn't normally need this; it's here for when the workflow is unavailable. If you're publishing to

--- a/bin/setup_release_secrets
+++ b/bin/setup_release_secrets
@@ -8,7 +8,7 @@
 # arguments. Everything is piped straight from its source into `gh secret set`.
 #
 #   bin/setup_release_secrets                        # use the key named in ~/.gradle/gradle.properties
-#   bin/setup_release_secrets --new-key team@x.com   # generate a dedicated release-signing key
+#   bin/setup_release_secrets --new-key team_pathfinder@cultureamp.com   # dedicated release-signing key
 #   bin/setup_release_secrets --dry-run              # check everything, change nothing
 
 set -euo pipefail
@@ -176,7 +176,7 @@ else
   else
     die "could not export $KEY_ID with that passphrase.
     Check 'grep signing.gnupg.passphrase $GRADLE_PROPS', or generate a
-    dedicated key instead with: $0 --new-key <team-alias@cultureamp.com>"
+    dedicated key instead with: $0 --new-key team_pathfinder@cultureamp.com"
   fi
 fi
 

--- a/bin/setup_release_secrets
+++ b/bin/setup_release_secrets
@@ -1,0 +1,352 @@
+#!/bin/bash
+# One-time setup for automated releases (see CONTRIBUTING.md).
+#
+# Creates the GitHub Environment that holds the Maven Central publishing credentials,
+# loads the four secrets into it, and optionally protects the release branch.
+#
+# Secret values are never printed, never written to disk, and never passed as command-line
+# arguments. Everything is piped straight from its source into `gh secret set`.
+#
+#   bin/setup_release_secrets                        # use the key named in ~/.gradle/gradle.properties
+#   bin/setup_release_secrets --new-key team@x.com   # generate a dedicated release-signing key
+#   bin/setup_release_secrets --dry-run              # check everything, change nothing
+
+set -euo pipefail
+
+REPO="cultureamp/kestrel"
+ENVIRONMENT="maven-central"
+RELEASE_BRANCH="master"
+KEYSERVER="keys.openpgp.org"
+GRADLE_PROPS="$HOME/.gradle/gradle.properties"
+
+DRY_RUN=false
+NEW_KEY_EMAIL=""
+KEY_ID=""
+SKIP_BRANCH_PROTECTION=false
+SKIP_VERIFY=false
+
+usage() {
+  sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<'USAGE'
+
+Options:
+  --new-key EMAIL           Generate a dedicated release-signing key for EMAIL instead of
+                            reusing a personal key. Recommended: a team alias, not a person.
+  --key KEYID               Use this existing key instead of the one in gradle.properties.
+  --dry-run                 Validate everything and report, but make no changes.
+  --skip-branch-protection  Don't touch branch protection on the release branch.
+  --skip-verify             Don't run the local test signature at the end.
+  --repo OWNER/NAME         Override the target repository.
+  -h, --help                Show this help.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --new-key) NEW_KEY_EMAIL="${2:?--new-key needs an email}"; shift 2 ;;
+    --key) KEY_ID="${2:?--key needs a key id}"; shift 2 ;;
+    --repo) REPO="${2:?--repo needs OWNER/NAME}"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    --skip-branch-protection) SKIP_BRANCH_PROTECTION=true; shift ;;
+    --skip-verify) SKIP_VERIFY=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$1"; }
+info() { printf '    %s\n' "$1"; }
+warn() { printf '    \033[33mwarning:\033[0m %s\n' "$1"; }
+die()  { printf '\n\033[31merror:\033[0m %s\n' "$1" >&2; exit 1; }
+
+# Wraps every mutating call so --dry-run is honoured in exactly one place.
+run() {
+  if $DRY_RUN; then info "would run: $*"; return 0; fi
+  "$@"
+}
+
+# Pipe a value into a secret without it ever being visible. Usage:
+#   producer_command | put_secret NAME
+put_secret() {
+  local name="$1" value
+  value=$(cat)
+  [ -n "$value" ] || die "refusing to set $name: the value was empty"
+  if $DRY_RUN; then
+    info "would set $name (${#value} bytes)"
+  else
+    printf '%s' "$value" | gh secret set "$name" --repo "$REPO" --env "$ENVIRONMENT"
+    info "set $name (${#value} bytes)"
+  fi
+}
+
+read_gradle_prop() {
+  [ -f "$GRADLE_PROPS" ] || return 0
+  sed -n "s/^$1=//p" "$GRADLE_PROPS" | tr -d '\n'
+}
+
+# ---------------------------------------------------------------------------- preflight
+
+step "Checking prerequisites"
+
+command -v gh  >/dev/null || die "the GitHub CLI (gh) is not installed"
+command -v gpg >/dev/null || die "gpg is not installed - try 'brew install gnupg'"
+gh auth status >/dev/null 2>&1 || die "not logged in to GitHub - run 'gh auth login'"
+info "gh and gpg present, authenticated as $(gh api user --jq .login)"
+
+if ! gh api "repos/$REPO" --jq '.permissions.admin' 2>/dev/null | grep -qx true; then
+  die "you need admin on $REPO to create environments and set environment secrets.
+    Ask a repo admin to run this script, or to grant you admin temporarily."
+fi
+info "admin on $REPO confirmed"
+
+$DRY_RUN && warn "dry run: nothing will be changed"
+
+# ---------------------------------------------------------------- signing key resolution
+
+step "Resolving the signing key"
+
+if [ -n "$NEW_KEY_EMAIL" ]; then
+  [ -n "$KEY_ID" ] && die "--new-key and --key are mutually exclusive"
+
+  info "Generating a dedicated release-signing key for $NEW_KEY_EMAIL."
+  info "Save the passphrase in 1Password BEFORE continuing - it cannot be recovered,"
+  info "and whoever maintains Kestrel next will need it."
+  echo
+  read -rsp "    Passphrase for the new key: " KEY_PASSPHRASE; echo
+  read -rsp "    Confirm passphrase: " confirm; echo
+  [ "$KEY_PASSPHRASE" = "$confirm" ] || die "passphrases did not match"
+  [ -n "$KEY_PASSPHRASE" ] || die "a release-signing key must have a passphrase"
+  unset confirm
+
+  if $DRY_RUN; then
+    info "would generate: rsa4096 sign-only, 2y expiry, 'Kestrel Release Signing <$NEW_KEY_EMAIL>'"
+    KEY_ID="DRYRUNKEYID00000"
+  else
+    gpg --batch --passphrase "$KEY_PASSPHRASE" --quick-generate-key \
+        "Kestrel Release Signing <$NEW_KEY_EMAIL>" rsa4096 sign 2y
+    KEY_ID=$(gpg --list-keys --keyid-format=long "$NEW_KEY_EMAIL" \
+             | awk '/^pub/ { split($2, a, "/"); print a[2]; exit }')
+    [ -n "$KEY_ID" ] || die "key generation appeared to succeed but the key could not be found"
+    info "generated key $KEY_ID"
+  fi
+else
+  if [ -z "$KEY_ID" ]; then
+    KEY_ID=$(read_gradle_prop 'signing\.gnupg\.keyName')
+    [ -n "$KEY_ID" ] || die "no key given and signing.gnupg.keyName is not set in $GRADLE_PROPS.
+    Pass --key KEYID, or --new-key EMAIL to create a dedicated release-signing key."
+    info "using signing.gnupg.keyName from $GRADLE_PROPS"
+  fi
+
+  # Resolve a short id or fingerprint to the canonical long id, and fail clearly if the
+  # keyring holds more than one match.
+  matches=$(gpg --list-secret-keys --keyid-format=long "$KEY_ID" 2>/dev/null \
+            | awk '/^sec/ { split($2, a, "/"); print a[2] }' || true)
+  count=$(printf '%s\n' "$matches" | grep -c . || true)
+  [ "$count" -eq 1 ] || die "expected exactly one secret key matching '$KEY_ID', found $count.
+    Run 'gpg -K --keyid-format=long' and pass an unambiguous --key."
+  KEY_ID="$matches"
+
+  expiry=$(gpg --list-keys --with-colons "$KEY_ID" | awk -F: '/^pub:/ { print $7; exit }')
+  info "using existing key $KEY_ID"
+  if [ -n "$expiry" ] && [ "$expiry" != "0" ]; then
+    info "expires $(date -r "$expiry" '+%Y-%m-%d' 2>/dev/null || echo "$expiry")"
+    [ "$expiry" -lt "$(date +%s)" ] && die "that key has expired; releases signed with it will be rejected"
+  fi
+
+  warn "this looks like a personal key. A dedicated key (--new-key) avoids tying releases"
+  warn "to one person, and means a leak doesn't force you to revoke your own identity key."
+
+  KEY_PASSPHRASE=$(read_gradle_prop 'signing\.gnupg\.passphrase')
+  if [ -n "$KEY_PASSPHRASE" ]; then
+    info "passphrase read from $GRADLE_PROPS"
+  else
+    read -rsp "    Passphrase for $KEY_ID: " KEY_PASSPHRASE; echo
+  fi
+fi
+
+# Prove the passphrase actually unlocks the key before we start changing anything on GitHub.
+step "Verifying the key can be exported"
+if $DRY_RUN && [ -n "$NEW_KEY_EMAIL" ]; then
+  info "skipped (no key was generated in a dry run)"
+else
+  if gpg --batch --pinentry-mode loopback --passphrase "$KEY_PASSPHRASE" \
+         --armor --export-secret-keys "$KEY_ID" 2>/dev/null \
+       | head -1 | grep -q 'BEGIN PGP PRIVATE KEY BLOCK'; then
+    info "passphrase accepted, private key exports cleanly"
+  else
+    die "could not export $KEY_ID with that passphrase.
+    Check 'grep signing.gnupg.passphrase $GRADLE_PROPS', or generate a
+    dedicated key instead with: $0 --new-key <team-alias@cultureamp.com>"
+  fi
+fi
+
+# ------------------------------------------------------------------- sonatype credentials
+
+step "Collecting Central Portal credentials"
+
+CENTRAL_USER="${CENTRAL_TOKEN_USERNAME:-}"
+CENTRAL_PASS="${CENTRAL_TOKEN_PASSWORD:-}"
+
+if [ -n "$CENTRAL_USER" ] && [ -n "$CENTRAL_PASS" ]; then
+  info "found CENTRAL_TOKEN_USERNAME and CENTRAL_TOKEN_PASSWORD in the environment"
+else
+  info "Values live in 1Password: Team Develop > Kestrel Sonatype Credentials"
+  [ -n "$CENTRAL_USER" ] || { read -rp  "    Central Portal token username: " CENTRAL_USER; }
+  [ -n "$CENTRAL_PASS" ] || { read -rsp "    Central Portal token password: " CENTRAL_PASS; echo; }
+fi
+[ -n "$CENTRAL_USER" ] && [ -n "$CENTRAL_PASS" ] || die "both Central Portal credentials are required"
+
+# ------------------------------------------------------------------------- environment
+
+step "Creating the '$ENVIRONMENT' environment"
+
+# No required reviewers: the pull request review is already an approval of the same change by
+# the same people. The branch policy is the control that matters - it stops these secrets
+# being readable by a job running on any branch other than the release branch.
+if $DRY_RUN; then
+  info "would create environment '$ENVIRONMENT' with no reviewers and no wait timer"
+else
+  gh api -X PUT "repos/$REPO/environments/$ENVIRONMENT" \
+    -F "wait_timer=0" \
+    -F "reviewers[]" \
+    -f "deployment_branch_policy[protected_branches]=false" \
+    -f "deployment_branch_policy[custom_branch_policies]=true" \
+    --silent
+  info "environment ready"
+fi
+
+step "Restricting '$ENVIRONMENT' to the $RELEASE_BRANCH branch"
+
+existing=""
+if ! $DRY_RUN; then
+  existing=$(gh api "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+             --jq '.branch_policies[].name' 2>/dev/null || true)
+fi
+
+if printf '%s\n' "$existing" | grep -qx "$RELEASE_BRANCH"; then
+  info "branch policy for '$RELEASE_BRANCH' already present"
+else
+  if $DRY_RUN; then
+    info "would add a deployment branch policy for '$RELEASE_BRANCH'"
+  else
+    gh api -X POST "repos/$REPO/environments/$ENVIRONMENT/deployment-branch-policies" \
+      -f "name=$RELEASE_BRANCH" -f "type=branch" --silent
+    info "only jobs running on '$RELEASE_BRANCH' can read these secrets"
+  fi
+fi
+
+# ----------------------------------------------------------------------------- secrets
+
+step "Loading the four secrets"
+
+printf '%s' "$CENTRAL_USER" | put_secret CENTRAL_TOKEN_USERNAME
+printf '%s' "$CENTRAL_PASS" | put_secret CENTRAL_TOKEN_PASSWORD
+printf '%s' "$KEY_PASSPHRASE" | put_secret GPG_SIGNING_PASSPHRASE
+
+if $DRY_RUN && [ -n "$NEW_KEY_EMAIL" ]; then
+  info "would set GPG_SIGNING_KEY from the generated key"
+else
+  gpg --batch --pinentry-mode loopback --passphrase "$KEY_PASSPHRASE" \
+      --armor --export-secret-keys "$KEY_ID" \
+    | put_secret GPG_SIGNING_KEY
+fi
+
+# ---------------------------------------------------------------------------- keyserver
+
+step "Publishing the public key to $KEYSERVER"
+info "Maven Central rejects artifacts it cannot verify against a published key."
+if $DRY_RUN && [ -n "$NEW_KEY_EMAIL" ]; then
+  info "would send the generated key to $KEYSERVER"
+else
+  if run gpg --keyserver "$KEYSERVER" --send-keys "$KEY_ID"; then
+    fingerprint=$(gpg --list-keys --with-colons "$KEY_ID" 2>/dev/null \
+                  | awk -F: '/^fpr:/ { print $10; exit }')
+    info "verify at https://keys.openpgp.org/search?q=$fingerprint"
+    info "(propagation can take a few minutes)"
+  else
+    warn "could not reach the keyserver. Retry later with:"
+    warn "  gpg --keyserver $KEYSERVER --send-keys $KEY_ID"
+  fi
+fi
+
+# --------------------------------------------------------------------- branch protection
+
+if $SKIP_BRANCH_PROTECTION; then
+  step "Skipping branch protection (--skip-branch-protection)"
+else
+  step "Protecting the $RELEASE_BRANCH branch"
+  info "Anyone who can merge to $RELEASE_BRANCH can reach these credentials, so requiring a"
+  info "reviewed pull request is what actually protects them."
+
+  if gh api "repos/$REPO/branches/$RELEASE_BRANCH/protection" >/dev/null 2>&1; then
+    info "branch protection already configured - leaving it alone"
+  elif $DRY_RUN; then
+    info "would require a pull request with 1 approving review on '$RELEASE_BRANCH'"
+  else
+    gh api -X PUT "repos/$REPO/branches/$RELEASE_BRANCH/protection" \
+      --input - --silent <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null
+}
+JSON
+    info "pull request with 1 approving review now required"
+  fi
+fi
+
+# ------------------------------------------------------------------------------- verify
+
+step "Verifying"
+
+if $DRY_RUN; then
+  info "dry run complete - nothing was changed"
+else
+  names=$(gh secret list --repo "$REPO" --env "$ENVIRONMENT" --json name --jq '.[].name' | sort | tr '\n' ' ')
+  info "secrets in '$ENVIRONMENT': $names"
+  for required in CENTRAL_TOKEN_PASSWORD CENTRAL_TOKEN_USERNAME GPG_SIGNING_KEY GPG_SIGNING_PASSPHRASE; do
+    printf '%s' "$names" | grep -qw "$required" || die "$required is missing from the environment"
+  done
+  info "all four secrets present"
+fi
+
+if $SKIP_VERIFY; then
+  info "skipping the local test signature (--skip-verify)"
+elif $DRY_RUN && [ -n "$NEW_KEY_EMAIL" ]; then
+  info "skipping the local test signature (no key was generated)"
+else
+  step "Test signature via the same code path CI uses"
+  info "This exercises useInMemoryPgpKeys rather than your gpg agent."
+  if GPG_SIGNING_KEY="$(gpg --batch --pinentry-mode loopback --passphrase "$KEY_PASSPHRASE" \
+                        --armor --export-secret-keys "$KEY_ID")" \
+     GPG_SIGNING_PASSPHRASE="$KEY_PASSPHRASE" \
+     ./gradlew --quiet signMavenJavaPublication; then
+    info "signing succeeded"
+  else
+    die "signing failed. The secrets are set, but a release would not be able to sign."
+  fi
+fi
+
+unset KEY_PASSPHRASE CENTRAL_PASS CENTRAL_USER
+
+step "Done"
+if $DRY_RUN; then
+  cat <<EOS
+    Re-run without --dry-run to apply.
+EOS
+else
+  cat <<EOS
+    Releases are now automatic. To cut one:
+      1. Bump base_version in gradle.properties
+      2. Add a '# <version>' section to CHANGELOG.md if there are breaking changes
+      3. Merge to $RELEASE_BRANCH
+
+    To check the plumbing without publishing, push any trivial commit to $RELEASE_BRANCH:
+    the detect job should skip with "already published to Maven Central".
+EOS
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,14 @@ signing {
     def skipSigning = Boolean.valueOf(System.getenv("SKIP_SIGNING"))
     if (!skipSigning)
     {
-        useGpgCmd()
+        // CI has no GPG keyring, so it passes the armoured key in directly. Locally the key
+        // stays in the gpg agent, configured by the signing.gnupg.* properties in ~/.gradle.
+        def signingKey = System.getenv("GPG_SIGNING_KEY")
+        if (signingKey) {
+            useInMemoryPgpKeys(signingKey, System.getenv("GPG_SIGNING_PASSPHRASE"))
+        } else {
+            useGpgCmd()
+        }
         sign publishing.publications.mavenJava
     }
 }


### PR DESCRIPTION
Releasing is currently a manual sequence of GPG and Gradle commands run on a laptop. This makes it automatic: **bump `base_version` in `gradle.properties`, merge to `master`, and the release happens** — build, test, sign, publish to Maven Central, tag `v<version>`, cut a GitHub release using the matching `CHANGELOG.md` section as notes.

The trigger is a real version bump, not just a push. `0.30.0` is already on Maven Central, so `detect` skips if the version is already published, if the tag exists, or if `base_version` didn't change. That makes this safe to merge as-is and safe to re-run after a partial failure. I tested the detect script against real git history: no-bump skips, `0.30.0`→`0.99.0` releases, docs-only commit after a bump skips, `-SNAPSHOT` hard-errors.

`build.gradle` gains `useInMemoryPgpKeys` when `GPG_SIGNING_KEY` is set, falling back to `useGpgCmd()` — CI has no keyring, local flow unchanged.

**Security** (public repo, credentials publish signed artefacts under `com.cultureamp` to an immutable registry): triggers only on `push` to `master` with no `pull_request` trigger, so fork PRs can never reach the secrets. Credentials sit in a `maven-central` environment restricted to `master`, default token permission is `contents: read`, and all actions are SHA-pinned. No environment approval gate — the PR review is the approval.

Not using the swag/changesets pattern: swag publishes to GitHub Packages with the run's ephemeral `GITHUB_TOKEN` and no signing, so it stores no credentials — Maven Central needs a persistent token *and* a GPG signature. Borrowed the trigger idea, dropped the machinery.

## Setup — one command, needs repo admin

```bash
bin/setup_release_secrets --dry-run   # check everything, change nothing
bin/setup_release_secrets             # apply
```

Creates the `maven-central` environment, restricts it to `master`, loads the four secrets, publishes the signing key to a keyserver, requires a reviewed PR on `master`, and ends with a real test signature through `useInMemoryPgpKeys` so a broken key fails there rather than mid-release. Secret values are piped straight from source to `gh secret set` — never printed, never written to disk, never passed as arguments. Safe to re-run.

I verified it with `gh` stubbed and real gpg/gradle: it resolves the key from `signing.gnupg.keyName`, confirms the passphrase unlocks it, and the test signature passes. Failure paths checked too — unknown key, wrong passphrase, and conflicting flags all fail before anything on GitHub is touched.

Two things it can't decide for you:

- **`--new-key <team-alias@cultureamp.com>`** generates a dedicated release-signing key instead of reusing a personal one. Worth doing: otherwise releases depend on one engineer's key staying valid, and a leak means revoking their identity key. The script warns when it detects a personal key.
- **Branch protection on `master`** — there is currently none, so anyone with write access can push straight to it. Merge review is the security boundary for these credentials, so the script sets it up unless you pass `--skip-branch-protection`.

Separately: `.buildkite/hooks/pre-command` tests for branch `main` but the default branch is `master`, so master builds have always run on `build-unrestricted`. Pre-existing, untouched here, worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
