### PR TITLE
Publish public-API dependencies at compile scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,32 @@ Notable upgrade steps, all of which apply to consuming code too:
 The one Kestrel API signature this changes is the lock hook: `blockingLockUntilTransactionEnd`
 and `pgAdvisoryXactLock` are now extensions on `JdbcTransaction` rather than `Transaction`,
 because `exec` moved to the JDBC-specific transaction type.
+# 0.31.0
+
+## Dependencies that appear in the public API are now `api` scope
+
+Kestrel exposes types from several of its dependencies in its own public signatures, but declared
+every one of them as `implementation`. Gradle publishes `implementation` as Maven `runtime` scope,
+so those types were missing from the compile classpath of anything depending on Kestrel. Consumers
+had to redeclare the dependency themselves just to compile against Kestrel's API.
+
+The affected types:
+
+- `Database` (`org.jetbrains.exposed.v1.jdbc`) in `RelationalDatabaseBookmarkStore` and
+  `RelationalDatabaseEventStore.create`, and `JdbcTransaction` in `blockingLockUntilTransactionEnd`
+  — from `exposed-jdbc`.
+- `Table`, `Column` and `ResultRow` in the `Events` table and the `jsonBody` hook — from
+  `exposed-core`.
+- `ObjectMapper` (`tools.jackson.databind`) in `RelationalDatabaseEventStore.create` and
+  `defaultObjectMapper` — reachable through `jackson-module-kotlin`.
+- `DateTime` in `Event.createdAt` — from `joda-time`.
+
+These four are now `api`, which the generated POM publishes at `compile` scope. `exposed-jodatime`,
+`exposed-json` and `jackson-datatype-joda` stay `implementation`, because only Kestrel's own
+internals reference them.
+
+This needs the `java-library` plugin rather than `java`, since the plain `java` plugin has no `api`
+configuration.
+
+Nothing is removed or renamed, so this is source and binary compatible. Consumers that already
+declare these dependencies can drop them, but nothing breaks if they keep them.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id 'java'
+    id 'java-library'
     id 'org.jetbrains.kotlin.jvm' version '2.2.21'
     id 'maven-publish'
     id 'signing'
@@ -152,17 +152,17 @@ compileTestKotlin {
 }
 
 dependencies {
-    implementation "tools.jackson.module:jackson-module-kotlin:$jackson_version"
+    api "tools.jackson.module:jackson-module-kotlin:$jackson_version" // ObjectMapper is in the public API
     implementation "tools.jackson.datatype:jackson-datatype-joda:$jackson_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     testImplementation "io.kotest:kotest-runner-junit5-jvm:4.6.2" // for kotest framework
     testImplementation "io.kotest:kotest-assertions-core-jvm:4.6.2" // for kotest core jvm assertions
     testImplementation "com.h2database:h2:2.3.232" // Exposed 1.x requires H2 2.x
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2"
-    implementation "joda-time:joda-time:2.10.10"
+    api "joda-time:joda-time:2.10.10" // DateTime is in the public API (Event.createdAt)
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "org.jetbrains.exposed:exposed-core:$exposed_version"
-    implementation "org.jetbrains.exposed:exposed-jdbc:$exposed_version"
+    api "org.jetbrains.exposed:exposed-core:$exposed_version" // Table/Column/ResultRow are in the public API
+    api "org.jetbrains.exposed:exposed-jdbc:$exposed_version" // Database/JdbcTransaction are in the public API
     implementation "org.jetbrains.exposed:exposed-jodatime:$exposed_version"
     implementation "org.jetbrains.exposed:exposed-json:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:2.0.11"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.30.0
+base_version=0.31.0
 group_id=com.cultureamp
 version_suffix=
 


### PR DESCRIPTION
Follow-up to a review comment on [career-pathways#3678](https://github.com/cultureamp/career-pathways/pull/3678#discussion_r3849426379), where @williamboxhall suggested fixing the scoping here.

## Problem

Kestrel exposes types from several dependencies in its own public signatures, but declares all of them as `implementation`. Gradle publishes `implementation` as Maven **runtime** scope, so those types are absent from the compile classpath of anything depending on Kestrel. Consumers have to redeclare the dependency just to compile against Kestrel's API.

career-pathways hit this twice while moving to 0.30.0, and needed two workarounds:

```kotlin
// because Database/transaction/selectAll were not on the compile classpath
implementation("org.jetbrains.exposed:exposed-jdbc:$exposed_version")
// because kestrel's ObjectMapper parameter type was not on the compile classpath
api("tools.jackson.module:jackson-module-kotlin:$jackson3_version")
```

## The leaks

| Type | Public location | Artifact |
|---|---|---|
| `Database` | `RelationalDatabaseBookmarkStore.db`, `RelationalDatabaseEventStore.create(db = ...)` | `exposed-jdbc` |
| `JdbcTransaction` | `blockingLockUntilTransactionEnd`, `pgAdvisoryXactLock` | `exposed-jdbc` |
| `Table`, `Column`, `ResultRow` | `Events`, the `jsonBody` hook | `exposed-core` |
| `ObjectMapper` | `RelationalDatabaseEventStore.create(objectMapper = ...)`, `defaultObjectMapper` | `jackson-databind`, via `jackson-module-kotlin` |
| `DateTime` | `Event.createdAt` | `joda-time` |

## Change

Those four move to `api`. `exposed-jodatime`, `exposed-json` and `jackson-datatype-joda` stay `implementation`, because only Kestrel internals touch them.

This needs `java-library` instead of `java`, since the plain `java` plugin has no `api` configuration.

Resulting POM scopes:

```
compile  org.jetbrains.exposed:exposed-core
compile  org.jetbrains.exposed:exposed-jdbc
compile  tools.jackson.module:jackson-module-kotlin
compile  joda-time:joda-time
runtime  org.jetbrains.exposed:exposed-jodatime
runtime  org.jetbrains.exposed:exposed-json
runtime  tools.jackson.datatype:jackson-datatype-joda
runtime  ... unchanged
```

## Verification

- `compileKotlin` and `compileTestKotlin` pass.
- The generated POM publishes exactly those four at `compile` and leaves everything else at `runtime`.
- Published 0.31.0 to maven local, pointed career-pathways at it, and **removed both workarounds above**. It compiles. That is the end-to-end proof this fixes the reported problem.
- The test runtime classpath is byte-identical to `master` (76 jars, no diff), so this cannot change test behaviour.

**On the test suite:** I could not get it green locally, and neither could I on `master`. `EventsSequenceStatsTest` is the only test needing Docker, and `testcontainers/ryuk` will not start under Rancher Desktop on my machine. `master` fails the same 7 specs with `--rerun-tasks`, so this is a pre-existing local environment issue rather than something introduced here. Relying on CI for the suite.

Nothing is removed or renamed, so this is source and binary compatible. Consumers may drop their redundant declarations, but keeping them is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)