### PR TITLE
Add entity-processors for projecting from a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,13 +134,18 @@ safe to read.
 
 Its cost is that any long-running transaction in the same database holds the reader up, since the
 boundary cannot tell one that will write the polled table from one that never will. That trades
-silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and once
-the oldest open transaction has held the boundary back for longer than `stallThreshold` (an hour by
-default) `stallBehaviour` decides what happens. `StallBehaviour.Throw`, the default, raises
+silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and
+`BatchedAsyncEntityProcessor` reports it directly when a poll reads nothing *and* the newest row in
+the table sits more than `stallThreshold` (an hour by default) beyond the boundary. Both of those
+timestamps come from the database — the head of the table against the oldest open transaction's
+`xact_start` — so no application clock is involved and clock skew cannot make a stall appear or
+disappear. A processor still reading rows below an old boundary is not stalled and reports nothing,
+which keeps a first run over a large table quiet while an unrelated transaction pins the boundary
+hours back.
+
+`stallBehaviour` decides what a stall does: `StallBehaviour.Throw`, the default, raises
 `SafeBoundaryStalledException` naming the pid and `application_name` of the sessions to go and
-close; `StallBehaviour.LogAndContinue` reports the same message and carries on reading, which is
-what a backfill behind a legitimately old boundary wants. Either way the report comes after the
-batch has been processed and bookmarked, so it never costs progress that was available.
+close; `StallBehaviour.LogAndContinue` reports the same message to a log and keeps polling.
 
 The `SafeBoundary` KDoc carries the rest of the argument, including why the boundary must be read in
 its own transaction and why the comparison has to be strict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,14 @@ disappear. A processor still reading rows below an old boundary is not stalled a
 which keeps a first run over a large table quiet while an unrelated transaction pins the boundary
 hours back.
 
+The head of the table is only queried when the boundary is old enough for a stall to be possible.
+`SafeBoundary.read()` returns both the boundary and the moment it was read — for
+`PostgresXactStartSafeBoundary` both come out of the one query, since `statement_timestamp()` is
+already the cap the boundary is computed against — and a row cannot be stamped after the boundary
+was read, so `head - safeBefore` can never exceed `readAt - safeBefore`. That makes the cheap
+comparison an exact pre-filter rather than a heuristic: at a 100ms poll interval it keeps a query
+per poll off an otherwise idle database without ever missing a stall.
+
 `stallBehaviour` decides what a stall does: `StallBehaviour.Throw`, the default, raises
 `SafeBoundaryStalledException` naming the pid and `application_name` of the sessions to go and
 close; `StallBehaviour.LogAndContinue` reports the same message to a log and keeps polling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,66 +98,29 @@ order and tiebroken on a `uuid` id, as the Confluent JDBC source connector does 
 they fit together.
 
 Nothing existing changes behaviour. `BookmarkLock` gains a `tryLock(bookmarkName: String)` overload
-with a default implementation delegating to the existing `tryLock(bookmark: Bookmark)`, so existing
-implementations are unaffected. Entity-bookmark locks are namespaced with an `entity:` prefix, so
-they cannot collide with an event-bookmark of the same name — `pg_try_advisory_lock` keys are one
-flat space per database, hashed from the name alone. Event-bookmark keys are deliberately left
-alone, since changing them would let two instances of a deployed event-processor hold different
-locks mid-rollout. The new stack uses `java.time` rather than joda, so it needs
-`exposed-java-time` alongside the `exposed-jodatime` the event-sourcing side continues to use.
+with a default implementation, so existing implementations are unaffected.
 
 Two things to know before adopting it.
 
-## Positions are naive timestamps holding UTC
+**Positions are naive timestamps holding UTC.** An `EntityPosition` carries a
+`java.time.LocalDateTime`, read from a `timestamp without time zone` column and carried around
+unconverted, so it means whatever the column holds — and the convention, here as in the events table,
+is that it holds UTC. Nothing in the library converts between zones. Map the column with Exposed's
+`datetime`, which needs `exposed-java-time`.
 
-An `EntityPosition` carries a `java.time.LocalDateTime`, read from a `timestamp without time zone`
-column and carried around unconverted — the same convention the events table uses for its own
-`created_at`. So a position means whatever the column holds, and the convention is that it holds UTC.
+**Reading by `updated_at` needs a `SafeBoundary`.** That column does not record commit order:
+Postgres `now()` is fixed when a transaction *starts*, so a transaction beginning at 12:00 and
+committing at 12:30 makes rows visible half an hour after the timestamp they carry, and a reader
+whose bookmark has meanwhile passed 12:00 never sees them again, with nothing to alert on.
+`BatchedAsyncEntityProcessor` therefore requires one, with no default because no single value is safe
+for every table. Pass `PostgresXactStartSafeBoundary`, which closes the race by construction from
+`pg_stat_activity` rather than probabilistically from a fixed delay.
 
-Nothing in the library converts between zones, so a column stamped in local time would be compared
-against a boundary read in UTC and the hold-back would be wrong by the offset. What the library does
-do is make its own defaults consistent: every `clock` parameter defaults to
-`LocalDateTime.now(ZoneOffset.UTC)` rather than `LocalDateTime::now`, and
-`PostgresXactStartSafeBoundary` converts with an explicit `AT TIME ZONE 'UTC'` rather than leaning on
-the session's `TimeZone`, which is connection-pool configuration a reader does not control.
+Its cost is a liveness one: any long-running transaction in the same database holds the reader up.
+Once rows have been piling up unreadable behind one for longer than `stallThreshold` (an hour by
+default), `BatchedAsyncEntityProcessor` throws `SafeBoundaryStalledException` naming the session to
+go and close — or logs it and keeps polling, if `stallBehaviour` says so.
 
-## Reading by `updated_at` needs a safe boundary
-
-That column does not record commit order. Postgres `now()` is fixed when a transaction *starts*, so a
-transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour after the
-timestamp they carry, and a reader whose bookmark has meanwhile passed 12:00 never sees those rows
-again — with no error and nothing to alert on. A fixed hold-back only makes that unlikely, and only
-while every writing transaction commits inside the delay.
-
-`BatchedAsyncEntityProcessor` therefore requires a `SafeBoundary`, and `EntitySource.getAfter` takes
-its upper bound as an exclusive `safeBefore`. There is no default, because no one value is safe for
-every table. `PostgresXactStartSafeBoundary` closes the race by construction — `min(xact_start)` from
-`pg_stat_activity`, capped at `statement_timestamp()` — so the reader never passes the start of the
-oldest transaction that could still commit, and no application clock is involved in deciding what is
-safe to read.
-
-Its cost is that any long-running transaction in the same database holds the reader up, since the
-boundary cannot tell one that will write the polled table from one that never will. That trades
-silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and
-`BatchedAsyncEntityProcessor` reports it directly when a poll reads nothing *and* the newest row in
-the table sits more than `stallThreshold` (an hour by default) beyond the boundary. Both of those
-timestamps come from the database — the head of the table against the oldest open transaction's
-`xact_start` — so no application clock is involved and clock skew cannot make a stall appear or
-disappear. A processor still reading rows below an old boundary is not stalled and reports nothing,
-which keeps a first run over a large table quiet while an unrelated transaction pins the boundary
-hours back.
-
-The head of the table is only queried when the boundary is old enough for a stall to be possible.
-`SafeBoundary.read()` returns both the boundary and the moment it was read — for
-`PostgresXactStartSafeBoundary` both come out of the one query, since `statement_timestamp()` is
-already the cap the boundary is computed against — and a row cannot be stamped after the boundary
-was read, so `head - safeBefore` can never exceed `readAt - safeBefore`. That makes the cheap
-comparison an exact pre-filter rather than a heuristic: at a 100ms poll interval it keeps a query
-per poll off an otherwise idle database without ever missing a stall.
-
-`stallBehaviour` decides what a stall does: `StallBehaviour.Throw`, the default, raises
-`SafeBoundaryStalledException` naming the pid and `application_name` of the sessions to go and
-close; `StallBehaviour.LogAndContinue` reports the same message to a log and keeps polling.
-
-The `SafeBoundary` KDoc carries the rest of the argument, including why the boundary must be read in
-its own transaction and why the comparison has to be strict.
+The `SafeBoundary` KDoc carries the reasoning: why the boundary must be read in its own transaction,
+why the comparison is exclusive, and why it refuses to report at all rather than report a boundary it
+cannot trust.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,57 @@ configuration.
 
 Nothing is removed or renamed, so this is source and binary compatible. Consumers that already
 declare these dependencies can drop them, but nothing breaks if they keep them.
+
+# 0.32.0
+
+## New features
+
+Adds an entity-processor stack, mirroring the event-processor stack for the case where the thing you
+want to project from is rows in a table rather than an event stream. Rows are read in `updated_at`
+order and tiebroken on a `uuid` id, as the Confluent JDBC source connector does in its
+"timestamp+incrementing" mode: see `EntitySource`, `EntityProcessor`, `EntityBookmarkStore`,
+`BatchedAsyncEntityProcessor`, `AsyncEntityProcessorMonitor` and `SafeBoundary`, and the
+[README](README.md#entity-processors-projecting-from-a-table-rather-than-an-event-stream) for how
+they fit together.
+
+Nothing existing changes behaviour. `BookmarkLock` gains a `tryLock(bookmarkName: String)` overload
+with a default implementation delegating to the existing `tryLock(bookmark: Bookmark)`, so existing
+implementations are unaffected. The new stack uses `java.time` rather than joda, so it needs
+`exposed-java-time` alongside the `exposed-jodatime` the event-sourcing side continues to use.
+
+Two things to know before adopting it.
+
+## Positions are naive timestamps holding UTC
+
+An `EntityPosition` carries a `java.time.LocalDateTime`, read from a `timestamp without time zone`
+column and carried around unconverted — the same convention the events table uses for its own
+`created_at`. So a position means whatever the column holds, and the convention is that it holds UTC.
+
+Nothing in the library converts between zones, so a column stamped in local time would be compared
+against a boundary read in UTC and the hold-back would be wrong by the offset. What the library does
+do is make its own defaults consistent: every `clock` parameter defaults to
+`LocalDateTime.now(ZoneOffset.UTC)` rather than `LocalDateTime::now`, and
+`PostgresXactStartSafeBoundary` converts with an explicit `AT TIME ZONE 'UTC'` rather than leaning on
+the session's `TimeZone`, which is connection-pool configuration a reader does not control.
+
+## Reading by `updated_at` needs a safe boundary
+
+That column does not record commit order. Postgres `now()` is fixed when a transaction *starts*, so a
+transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour after the
+timestamp they carry, and a reader whose bookmark has meanwhile passed 12:00 never sees those rows
+again — with no error and nothing to alert on. A fixed hold-back only makes that unlikely, and only
+while every writing transaction commits inside the delay.
+
+`BatchedAsyncEntityProcessor` therefore requires a `SafeBoundary`, and `EntitySource.getAfter` takes
+its upper bound as an exclusive `safeBefore`. There is no default, because no one value is safe for
+every table. `PostgresXactStartSafeBoundary` closes the race by construction — `min(xact_start)` from
+`pg_stat_activity`, capped at `statement_timestamp()` — so the reader never passes the start of the
+oldest transaction that could still commit, and no application clock is involved in deciding what is
+safe to read.
+
+Its cost is that any long-running transaction in the same database holds the reader up, since the
+boundary cannot tell one that will write the polled table from one that never will. That trades
+silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and after
+`stallThreshold` (an hour by default) the processor throws `SafeBoundaryStalledException` naming the
+session to go and close. The `SafeBoundary` KDoc carries the rest of the argument, including why the
+boundary must be read in its own transaction and why the comparison has to be strict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,11 @@ they fit together.
 
 Nothing existing changes behaviour. `BookmarkLock` gains a `tryLock(bookmarkName: String)` overload
 with a default implementation delegating to the existing `tryLock(bookmark: Bookmark)`, so existing
-implementations are unaffected. The new stack uses `java.time` rather than joda, so it needs
+implementations are unaffected. Entity-bookmark locks are namespaced with an `entity:` prefix, so
+they cannot collide with an event-bookmark of the same name — `pg_try_advisory_lock` keys are one
+flat space per database, hashed from the name alone. Event-bookmark keys are deliberately left
+alone, since changing them would let two instances of a deployed event-processor hold different
+locks mid-rollout. The new stack uses `java.time` rather than joda, so it needs
 `exposed-java-time` alongside the `exposed-jodatime` the event-sourcing side continues to use.
 
 Two things to know before adopting it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ committing at 12:30 makes rows visible half an hour after the timestamp they car
 whose bookmark has meanwhile passed 12:00 never sees them again, with nothing to alert on.
 `BatchedAsyncEntityProcessor` therefore requires one, with no default because no single value is safe
 for every table. Pass `PostgresXactStartSafeBoundary`, which closes the race by construction from
-`pg_stat_activity` rather than probabilistically from a fixed delay.
+`pg_stat_activity`, with nothing to tune.
 
 Its cost is a liveness one: any long-running transaction in the same database holds the reader up.
 Once rows have been piling up unreadable behind one for longer than `stallThreshold` (an hour by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,13 @@ safe to read.
 
 Its cost is that any long-running transaction in the same database holds the reader up, since the
 boundary cannot tell one that will write the polled table from one that never will. That trades
-silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and after
-`stallThreshold` (an hour by default) the processor throws `SafeBoundaryStalledException` naming the
-session to go and close. The `SafeBoundary` KDoc carries the rest of the argument, including why the
-boundary must be read in its own transaction and why the comparison has to be strict.
+silent data loss for a visible stall: `AsyncEntityProcessorMonitor` reports it as latency, and once
+the oldest open transaction has held the boundary back for longer than `stallThreshold` (an hour by
+default) `stallBehaviour` decides what happens. `StallBehaviour.Throw`, the default, raises
+`SafeBoundaryStalledException` naming the pid and `application_name` of the sessions to go and
+close; `StallBehaviour.LogAndContinue` reports the same message and carries on reading, which is
+what a backfill behind a legitimately old boundary wants. Either way the report comes after the
+batch has been processed and bookmarked, so it never costs progress that was available.
+
+The `SafeBoundary` KDoc carries the rest of the argument, including why the boundary must be read in
+its own transaction and why the comparison has to be strict.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ events (
 - **PostgreSQL** (production) / **H2 2.x** (testing) for event storage
 - **Jetbrains Exposed 1.3.1** - Kotlin SQL DSL for database access
 - **Jackson 3.1.0** - JSON serialization with snake_case naming
-- **Joda-Time** - Date/time handling (not java.time)
+- **Joda-Time** - Date/time handling on the event-sourcing side; the entity-processor side uses
+  `java.time.LocalDateTime`, naive and holding UTC
 - **Kotest 4.6.2** - Testing framework with assertions
 - **Testcontainers** - PostgreSQL integration testing
 
@@ -114,7 +115,7 @@ the rest are declared inline in `build.gradle`.
 ### Important Dependencies
 ```kotlin
 // Database
-exposed-core, exposed-jdbc, exposed-jodatime, exposed-json  // 1.3.1
+exposed-core, exposed-jdbc, exposed-jodatime, exposed-java-time, exposed-json  // 1.3.1
 postgresql:42.7.3
 
 // Serialization

--- a/README.md
+++ b/README.md
@@ -521,6 +521,50 @@ val entityProcessorMonitor = AsyncEntityProcessorMonitor(asyncEntityProcessors) 
 in the table, and `latencyMs` is how stale the bookmark is in wall-clock terms. Prefer alerting on `latencyMs`, since it
 keeps growing when a processor is stuck even if nothing new is being written.
 
+#### Maintaining the polled column
+
+Kestrel only ever reads the polled column. Whatever maintains it is yours, and the boundary's correctness depends on
+it, so it is worth getting right in one go. On Postgres:
+
+```sql
+CREATE FUNCTION set_updated_at_clock_utc() RETURNS trigger LANGUAGE plpgsql AS $$
+  BEGIN
+    NEW.updated_at = GREATEST(clock_timestamp(), transaction_timestamp()) AT TIME ZONE 'UTC';
+    RETURN NEW;
+  END;
+$$;
+
+CREATE TRIGGER set_goal_relationships_updated_at BEFORE INSERT OR UPDATE
+  ON goal_relationships FOR EACH ROW EXECUTE PROCEDURE set_updated_at_clock_utc();
+
+CREATE INDEX goal_relationships_updated_at_id ON goal_relationships (updated_at, id);
+```
+
+Each part of that prevents a specific failure:
+
+- **`clock_timestamp()`, not `now()`.** `now()` is `transaction_timestamp()`, fixed when the transaction starts, so a
+  transaction that began earlier but writes later stamps a *smaller* value than the row already had. The column then
+  moves backwards and a row that has already been read is missed. `clock_timestamp()` reads the wall clock at the
+  moment of the write, and because a `BEFORE` trigger runs after the row lock is taken, two transactions updating one
+  row are serialised and the later writer necessarily reads a later clock.
+- **`GREATEST(..., transaction_timestamp())`.** The boundary is the oldest open transaction's `xact_start`, and
+  safety needs every row stamped at or after *its own* `xact_start`. `transaction_timestamp()` is exactly that value,
+  so the `GREATEST` guarantees it even if the system clock steps backwards mid-transaction — `clock_timestamp()` reads
+  `CLOCK_REALTIME`, which is corrected rather than monotonic. In the ordinary case it returns `clock_timestamp()`
+  unchanged.
+- **`AT TIME ZONE 'UTC'`, into a `timestamp without time zone`.** Positions are naive UTC and Kestrel converts the
+  boundary the same explicit way, so neither side depends on the session's `TimeZone`.
+- **`BEFORE INSERT OR UPDATE`, assigning unconditionally, with no column default.** The application must not be able
+  to supply the value, or it can supply one below the boundary or below the row's previous value. Note that an ORM may
+  send a value whether you want it to or not — Exposed needs a `clientDefault` on a non-nullable column to permit a
+  `batchInsert` — and an unconditional trigger is what makes that harmless. A trigger guarded with
+  `WHEN (NEW.updated_at IS NULL)` would let the application's clock win.
+- **An index on `(updated_at, id)`**, which is the order rows are read in. Make it partial if you pass a `filter`, so
+  it serves the filtered read and the head query too.
+
+Worth testing directly, since none of it fails loudly: that a client-supplied value is ignored, that two rows written
+in one transaction get increasing values, and that an update moves the value forward.
+
 #### Things to watch out for
 
 - **Choosing the polled column.** Whatever you pass as `updatedAtColumn` has to advance on *every* change you care
@@ -546,10 +590,6 @@ keeps growing when a processor is stuck even if nothing new is being written.
   between zones, so a column stamped in local time would be compared against a UTC boundary and be wrong by the
   offset; stamp it in UTC and every clock in this API agrees with it. Being nanosecond-precision, a `LocalDateTime`
   round-trips a `timestamp` exactly, so the column needs no particular precision.
-- **Stamp the polled column `GREATEST(clock_timestamp(), transaction_timestamp()) AT TIME ZONE 'UTC'`.** A trigger
-  recommendation, not something the library can do for you. The `GREATEST` keeps a row's stamp at or after its own
-  `xact_start` even if the system clock steps backwards mid-transaction, and returns `clock_timestamp()` unchanged
-  otherwise.
 - **You only ever see current state.** Unlike an event stream, a table exposes the latest version of each row. A row
   updated twice in quick succession may only be processed once, rows are seen in `updated_at` order rather than
   creation order, and deletes aren't visible at all unless they're soft deletes. Entity-processors need to be

--- a/README.md
+++ b/README.md
@@ -532,10 +532,9 @@ keeps growing when a processor is stuck even if nothing new is being written.
   transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour
   after the timestamp they carry — and a reader whose bookmark has meanwhile passed 12:00 never sees them again, with
   nothing to alert on. Pass `PostgresXactStartSafeBoundary(database)`, which never lets the reader past the start of the
-  oldest transaction that could still commit. There is no default because no one value is safe for every table:
-  `SafeBoundary.unsafeFixedDelay` is the "now minus a delay" alternative, named for the fact that it holds only while
-  every writing transaction commits inside the delay. The cost of the real boundary is that any long-running
-  transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
+  oldest transaction that could still commit. There is no default, because holding reads back by a fixed delay instead
+  is only probabilistically right — it works while every writing transaction commits inside the delay, which nothing
+  enforces. The cost of the real boundary is that any long-running transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
   in the table sits more than `stallThreshold` (an hour) beyond the boundary — both timestamps database-generated, so no
   application clock is involved. The head of the table is only queried when the boundary is old enough for that to be
   possible, which it works out from the `readAt` that comes back with every boundary reading for free. A processor still working through rows below an old boundary is not a stall and says

--- a/README.md
+++ b/README.md
@@ -537,7 +537,8 @@ keeps growing when a processor is stuck even if nothing new is being written.
   every writing transaction commits inside the delay. The cost of the real boundary is that any long-running
   transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
   in the table sits more than `stallThreshold` (an hour) beyond the boundary — both timestamps database-generated, so no
-  application clock is involved. A processor still working through rows below an old boundary is not a stall and says
+  application clock is involved. The head of the table is only queried when the boundary is old enough for that to be
+  possible, which it works out from the `readAt` that comes back with every boundary reading for free. A processor still working through rows below an old boundary is not a stall and says
   nothing. `stallBehaviour` decides what a stall does: `StallBehaviour.Throw`, the default, raises
   `SafeBoundaryStalledException` naming the session to close, while `StallBehaviour.LogAndContinue` reports it to a log
   and keeps polling. The `SafeBoundary` KDoc has the full argument.

--- a/README.md
+++ b/README.md
@@ -535,11 +535,12 @@ keeps growing when a processor is stuck even if nothing new is being written.
   oldest transaction that could still commit. There is no default because no one value is safe for every table:
   `SafeBoundary.unsafeFixedDelay` is the "now minus a delay" alternative, named for the fact that it holds only while
   every writing transaction commits inside the delay. The cost of the real boundary is that any long-running
-  transaction in the same database holds the reader up. Once the oldest open transaction has held the boundary back for
-  longer than `stallThreshold` (an hour), `stallBehaviour` decides what happens: `StallBehaviour.Throw`, the default,
-  raises `SafeBoundaryStalledException` naming the session to close, while `StallBehaviour.LogAndContinue` reports and
-  keeps reading — the right mode for a backfill running behind a legitimately old boundary. The `SafeBoundary` KDoc has
-  the full argument.
+  transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
+  in the table sits more than `stallThreshold` (an hour) beyond the boundary — both timestamps database-generated, so no
+  application clock is involved. A processor still working through rows below an old boundary is not a stall and says
+  nothing. `stallBehaviour` decides what a stall does: `StallBehaviour.Throw`, the default, raises
+  `SafeBoundaryStalledException` naming the session to close, while `StallBehaviour.LogAndContinue` reports it to a log
+  and keeps polling. The `SafeBoundary` KDoc has the full argument.
 - **Positions are `java.time.LocalDateTime` holding UTC, not joda `DateTime`** — the opposite of the event-sourcing
   side, which is joda throughout. A position is read straight out of a `timestamp without time zone` column (map it
   with Exposed's `datetime`) and carried unconverted, so it means whatever the column holds. Nothing here converts

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ update a "bookmark" representing the sequence number of the last processed event
 - [**AsyncEventProcessorMonitor**](https://github.com/cultureamp/kotlin-eventsourcing/blob/master/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessorMonitor.kt) -
 *Provides a mechanism to establish how far `EventProcessor` bookmarks/processing is lagging behind the head of the event
 stream.*
+- [**EntitySource**](https://github.com/cultureamp/kotlin-eventsourcing/blob/master/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt) -
+*Like an `EventSource`, but reads rows from a table in `updated_at` order (tiebreaking on the row's `uuid` id) rather
+than events in sequence order. Along with `EntityProcessor`, `EntityBookmarkStore` and `BatchedAsyncEntityProcessor`,
+this lets you build a projector over a table you don't own. See
+[Entity-processors](#entity-processors-projecting-from-a-table-rather-than-an-event-stream).*
 
 ## Getting Started
 
@@ -436,6 +441,116 @@ thread(start = true, isDaemon = false, name = "eventProcessorMonitor") {
     }
 }
 ```
+
+### Entity-processors (projecting from a table rather than an event stream)
+
+Sometimes the data you want to project isn't an event stream at all — it's rows in a table owned by some other system.
+Kestrel mirrors the whole event-processor stack for that case, reading rows in `updated_at` order and tiebreaking on a
+`uuid` id, the same way the
+[Confluent JDBC source connector](https://docs.confluent.io/kafka-connectors/jdbc/current/overview.html) does in its
+"timestamp+incrementing" mode. Each event-sourcing piece has an entity equivalent:
+
+| Event stream               | Entity table                       | Notes                                                        |
+|----------------------------|------------------------------------|--------------------------------------------------------------|
+| `sequence: Long`           | `EntityPosition(updatedAt, id)`    | Total ordering, with the id as the tiebreaker. A null position is the equivalent of sequence `0` |
+| `SequencedEvent`           | `PositionedEntity`                 |                                                              |
+| `EventSource`              | `EntitySource`                     | A repository call: "give me rows after this position"         |
+| `EventProcessor`           | `EntityProcessor`                  |                                                              |
+| `BookmarkStore`            | `EntityBookmarkStore`              | Bookmarks store `(last_updated_at, last_id)` instead of a sequence |
+| `BatchedAsyncEventProcessor` | `BatchedAsyncEntityProcessor`    |                                                              |
+| `EventsSequenceStats`      | `EntityUpdatedAtStats`             | The head of the stream, i.e. the newest `updated_at`         |
+| `AsyncEventProcessorMonitor` | `AsyncEntityProcessorMonitor`    | Reports lag in milliseconds rather than in sequence numbers   |
+| `Lag`                      | `EntityLag`                        |                                                              |
+
+The source can be any function that takes a position, an exclusive upper bound on `updated_at`, and a batch size:
+
+```kotlin
+val entitySource = EntitySource.from { after, safeBefore, batchSize -> goalRelationshipRepository.updatedAfter(after, safeBefore, batchSize) }
+```
+
+Writing one by hand means honouring the contract documented on `EntitySource`: return only rows strictly after `after`
+and strictly before `safeBefore`, in ascending `(updated_at, id)` order. A source that returns a row its bookmark is
+already on, or returns rows out of order, would silently skip rows or reprocess one forever, so
+`BatchedAsyncEntityProcessor` checks each row as it goes and throws `EntitySourceStalledException` or
+`EntitySourceOrderingException` instead.
+
+Or, for an [Exposed](https://github.com/JetBrains/Exposed) table, use the provided implementation, which doubles as the
+`EntityUpdatedAtStats` used for lag monitoring:
+
+```kotlin
+val entitySource = RelationalDatabaseEntitySource(
+    db = database,
+    table = GoalRelationships,
+    updatedAtColumn = GoalRelationships.updatedAt,
+    idColumn = GoalRelationships.id,
+    rowToEntity = { GoalRelationship(it[GoalRelationships.id], it[GoalRelationships.childGoalId], it[GoalRelationships.updatedAt]) },
+)
+```
+
+The polled column doesn't have to be called `updated_at`; it just has to move forward every time a row changes. See
+[choosing the polled column](#things-to-watch-out-for) below, because getting this wrong silently misses updates.
+
+Wiring it up then looks just like an `AsyncEventProcessor`:
+
+```kotlin
+val bookmarkStore = RelationalDatabaseEntityBookmarkStore(database).also { it.createSchemaIfNotExists() }
+val asyncEntityProcessor = BatchedAsyncEntityProcessor(
+    entitySource = entitySource,
+    entityUpdatedAtStats = entitySource,
+    bookmarkStore = bookmarkStore,
+    bookmarkName = "GoalRelationshipNames",
+    entityProcessor = EntityProcessor.from(goalRelationshipProjector::project),
+    safeBoundary = PostgresXactStartSafeBoundary(database),
+)
+thread(start = true, isDaemon = false, name = asyncEntityProcessor.bookmarkName) {
+    ExponentialBackoff(onFailure = { e, _ -> println(e) }).run {
+        asyncEntityProcessor.processOneBatch()
+    }
+}
+```
+
+And monitoring works the same way, with lag expressed in milliseconds:
+
+```kotlin
+val entityProcessorMonitor = AsyncEntityProcessorMonitor(asyncEntityProcessors) {
+    println("msg='Lag calculation for entity-processor' name='${it.name}' lagMs=${it.lagMs} latencyMs=${it.latencyMs}")
+}
+```
+
+`EntityLag` exposes two numbers, because they fail differently: `lagMs` is how far the bookmark is behind the newest row
+in the table, and `latencyMs` is how stale the bookmark is in wall-clock terms. Prefer alerting on `latencyMs`, since it
+keeps growing when a processor is stuck even if nothing new is being written.
+
+#### Things to watch out for
+
+- **Choosing the polled column.** Whatever you pass as `updatedAtColumn` has to advance on *every* change you care
+  about, because that column is the only thing the processor watches. Polling a `created_at` works fine for
+  insert-only tables, but if rows are later mutated — soft-deleted by stamping a `deleted_at`, say — those changes are
+  invisible, since `created_at` doesn't move. A table without a real `updated_at` needs one adding, or a trigger to
+  maintain it, before a processor over it can see updates rather than just inserts.
+- **`updated_at` doesn't record commit order, which is what `safeBoundary` is for.** Postgres `now()` is fixed when a
+  transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour
+  after the timestamp they carry — and a reader whose bookmark has meanwhile passed 12:00 never sees them again, with
+  nothing to alert on. Pass `PostgresXactStartSafeBoundary(database)`, which never lets the reader past the start of the
+  oldest transaction that could still commit. There is no default because no one value is safe for every table:
+  `SafeBoundary.unsafeFixedDelay` is the "now minus a delay" alternative, named for the fact that it holds only while
+  every writing transaction commits inside the delay. The cost of the real boundary is that any long-running
+  transaction in the same database holds the reader up, and after `stallThreshold` (an hour) the processor throws
+  `SafeBoundaryStalledException` naming the session to close. The `SafeBoundary` KDoc has the full argument.
+- **Positions are `java.time.LocalDateTime` holding UTC, not joda `DateTime`** — the opposite of the event-sourcing
+  side, which is joda throughout. A position is read straight out of a `timestamp without time zone` column (map it
+  with Exposed's `datetime`) and carried unconverted, so it means whatever the column holds. Nothing here converts
+  between zones, so a column stamped in local time would be compared against a UTC boundary and be wrong by the
+  offset; stamp it in UTC and every clock in this API agrees with it. Being nanosecond-precision, a `LocalDateTime`
+  round-trips a `timestamp` exactly, so the column needs no particular precision.
+- **Stamp the polled column `GREATEST(clock_timestamp(), transaction_timestamp()) AT TIME ZONE 'UTC'`.** A trigger
+  recommendation, not something the library can do for you. The `GREATEST` keeps a row's stamp at or after its own
+  `xact_start` even if the system clock steps backwards mid-transaction, and returns `clock_timestamp()` unchanged
+  otherwise.
+- **You only ever see current state.** Unlike an event stream, a table exposes the latest version of each row. A row
+  updated twice in quick succession may only be processed once, rows are seen in `updated_at` order rather than
+  creation order, and deletes aren't visible at all unless they're soft deletes. Entity-processors need to be
+  idempotent for the same reasons event-processors do.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Kestrel mirrors the whole event-processor stack for that case, reading rows in `
 | `SequencedEvent`           | `PositionedEntity`                 |                                                              |
 | `EventSource`              | `EntitySource`                     | A repository call: "give me rows after this position"         |
 | `EventProcessor`           | `EntityProcessor`                  |                                                              |
-| `BookmarkStore`            | `EntityBookmarkStore`              | Bookmarks store `(last_updated_at, last_id)` instead of a sequence |
+| `BookmarkStore`            | `EntityBookmarkStore`              | Bookmarks store `(entity_last_updated_at, entity_last_id)` instead of a sequence |
 | `BatchedAsyncEventProcessor` | `BatchedAsyncEntityProcessor`    |                                                              |
 | `EventsSequenceStats`      | `EntityUpdatedAtStats`             | The head of the stream, i.e. the newest `updated_at`         |
 | `AsyncEventProcessorMonitor` | `AsyncEntityProcessorMonitor`    | Reports lag in milliseconds rather than in sequence numbers   |
@@ -535,8 +535,11 @@ keeps growing when a processor is stuck even if nothing new is being written.
   oldest transaction that could still commit. There is no default because no one value is safe for every table:
   `SafeBoundary.unsafeFixedDelay` is the "now minus a delay" alternative, named for the fact that it holds only while
   every writing transaction commits inside the delay. The cost of the real boundary is that any long-running
-  transaction in the same database holds the reader up, and after `stallThreshold` (an hour) the processor throws
-  `SafeBoundaryStalledException` naming the session to close. The `SafeBoundary` KDoc has the full argument.
+  transaction in the same database holds the reader up. Once the oldest open transaction has held the boundary back for
+  longer than `stallThreshold` (an hour), `stallBehaviour` decides what happens: `StallBehaviour.Throw`, the default,
+  raises `SafeBoundaryStalledException` naming the session to close, while `StallBehaviour.LogAndContinue` reports and
+  keeps reading — the right mode for a backfill running behind a legitimately old boundary. The `SafeBoundary` KDoc has
+  the full argument.
 - **Positions are `java.time.LocalDateTime` holding UTC, not joda `DateTime`** — the opposite of the event-sourcing
   side, which is joda throughout. A position is read straight out of a `timestamp without time zone` column (map it
   with Exposed's `datetime`) and carried unconverted, so it means whatever the column holds. Nothing here converts

--- a/README.md
+++ b/README.md
@@ -559,8 +559,8 @@ Each part of that prevents a specific failure:
   send a value whether you want it to or not — Exposed needs a `clientDefault` on a non-nullable column to permit a
   `batchInsert` — and an unconditional trigger is what makes that harmless. A trigger guarded with
   `WHEN (NEW.updated_at IS NULL)` would let the application's clock win.
-- **An index on `(updated_at, id)`**, which is the order rows are read in. Make it partial if you pass a `filter`, so
-  it serves the filtered read and the head query too.
+- **An index on `(updated_at, id)`**, which is the order rows are read in. If you pass a `filter`, a partial index
+  matching it serves both the read and the head query.
 
 Worth testing directly, since none of it fails loudly: that a client-supplied value is ignored, that two rows written
 in one transaction get increasing values, and that an update moves the value forward.
@@ -594,6 +594,12 @@ in one transaction get increasing values, and that an update moves the value for
   updated twice in quick succession may only be processed once, rows are seen in `updated_at` order rather than
   creation order, and deletes aren't visible at all unless they're soft deletes. Entity-processors need to be
   idempotent for the same reasons event-processors do.
+- **Don't `filter` out soft-deleted rows.** It looks like the obvious use for `filter`, and it is the one thing a
+  published projection must not do: a soft delete is the *only* way a deletion can reach a projection at all, since a
+  hard-deleted row simply stops existing. Filtering the flag out means the row stops being updated rather than being
+  reported as deleted, so a consumer keeps the last value it saw forever, with nothing anywhere recording that the row
+  went away. Read the flag in `rowToEntity` and let the processor decide what a delete means — a tombstone, usually.
+  Keep `filter` for narrowing *which* rows a processor is responsible for, such as one account or one shard.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -532,9 +532,8 @@ keeps growing when a processor is stuck even if nothing new is being written.
   transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour
   after the timestamp they carry — and a reader whose bookmark has meanwhile passed 12:00 never sees them again, with
   nothing to alert on. Pass `PostgresXactStartSafeBoundary(database)`, which never lets the reader past the start of the
-  oldest transaction that could still commit. There is no default, because holding reads back by a fixed delay instead
-  is only probabilistically right — it works while every writing transaction commits inside the delay, which nothing
-  enforces. The cost of the real boundary is that any long-running transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
+  oldest transaction that could still commit, and needs no tuning — it is derived entirely from database state. Its cost
+  is that any long-running transaction in the same database holds the reader up. That is reported when a poll reads nothing *and* the newest row
   in the table sits more than `stallThreshold` (an hour) beyond the boundary — both timestamps database-generated, so no
   application clock is involved. The head of the table is only queried when the boundary is old enough for that to be
   possible, which it works out from the `readAt` that comes back with every boundary reading for free. A processor still working through rows below an old boundary is not a stall and says

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     api "org.jetbrains.exposed:exposed-core:$exposed_version" // Table/Column/ResultRow are in the public API
     api "org.jetbrains.exposed:exposed-jdbc:$exposed_version" // Database/JdbcTransaction are in the public API
-    implementation "org.jetbrains.exposed:exposed-jodatime:$exposed_version"
+    implementation "org.jetbrains.exposed:exposed-jodatime:$exposed_version" // event-sourcing side, which is joda
+    implementation "org.jetbrains.exposed:exposed-java-time:$exposed_version" // entity-processor side, which is java.time
     implementation "org.jetbrains.exposed:exposed-json:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:2.0.11"
     implementation "org.postgresql:postgresql:42.7.3" // needed for driver in DemonstrateEventSequenceIdGaps.kt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-base_version=0.31.0
+base_version=0.32.0
 group_id=com.cultureamp
 version_suffix=
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitor.kt
@@ -1,0 +1,55 @@
+package com.cultureamp.eventsourcing
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * Reports how far each [AsyncEntityProcessor] is lagging behind the head of its entity table, analogous to
+ * [AsyncEventProcessorMonitor]. Since positions are timestamps rather than sequence numbers, lag is measured in
+ * milliseconds.
+ *
+ * @param clock reads UTC, like the positions it is compared against. A local-time reading would offset every
+ * [EntityLag.latencyMs] by the JVM's zone.
+ */
+class AsyncEntityProcessorMonitor(
+    private val asyncEntityProcessors: List<AsyncEntityProcessor<*>>,
+    private val metrics: (EntityLag) -> Unit,
+    private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) },
+) {
+    fun run() {
+        val lags = asyncEntityProcessors.map {
+            val bookmarkPosition = it.bookmarkStore.bookmarkFor(it.bookmarkName).position
+            val lastUpdatedAt = it.entityUpdatedAtStats.lastUpdatedAt()
+            EntityLag(
+                name = it.bookmarkName,
+                bookmarkPosition = bookmarkPosition,
+                lastUpdatedAt = lastUpdatedAt,
+                now = clock(),
+            )
+        }
+
+        lags.forEach {
+            metrics(it)
+        }
+    }
+}
+
+/**
+ * @property lagMs how far the bookmark is behind the newest row in the table. Null when there is nothing to compare:
+ * either the table is empty, or the processor has not yet processed anything (in which case [hasStarted] is false and
+ * the real lag is "the whole table").
+ * @property latencyMs how stale the bookmark is in wall-clock terms. Unlike [lagMs] this keeps growing while a
+ * processor is stuck, even if nothing new is being written, so it is usually the more useful thing to alert on.
+ */
+data class EntityLag(
+    val name: String,
+    val bookmarkPosition: EntityPosition?,
+    val lastUpdatedAt: LocalDateTime?,
+    val now: LocalDateTime,
+) {
+    val hasStarted: Boolean = bookmarkPosition != null
+    val bookmarkUpdatedAt: LocalDateTime? = bookmarkPosition?.updatedAt
+    val lagMs: Long? = if (bookmarkUpdatedAt != null && lastUpdatedAt != null) Duration.between(bookmarkUpdatedAt, lastUpdatedAt).toMillis() else null
+    val latencyMs: Long? = bookmarkUpdatedAt?.let { Duration.between(it, now).toMillis() }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
@@ -1,0 +1,174 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.common.Action
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlin.random.Random
+
+interface BookmarkedEntityProcessor<E> {
+    val bookmarkStore: EntityBookmarkStore
+    val bookmarkName: String
+    val entityProcessor: EntityProcessor<E>
+
+    companion object {
+        fun <E> from(bookmarkStore: EntityBookmarkStore, bookmarkName: String, entityProcessor: EntityProcessor<E>) = object : BookmarkedEntityProcessor<E> {
+            override val bookmarkStore = bookmarkStore
+            override val bookmarkName = bookmarkName
+            override val entityProcessor = entityProcessor
+        }
+    }
+}
+
+interface AsyncEntityProcessor<E> : BookmarkedEntityProcessor<E> {
+    val entitySource: EntitySource<E>
+    val entityUpdatedAtStats: EntityUpdatedAtStats
+}
+
+/**
+ * Reads rows from an [EntitySource] in `(updated_at, id)` order, dispatches them to an [EntityProcessor], and records
+ * progress as an [EntityPosition] in an [EntityBookmarkStore] — the entity-table equivalent of
+ * [BatchedAsyncEventProcessor]. It behaves like the
+ * [`timestamp+incrementing` mode](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/overview.html#incremental-query-modes)
+ * of the Confluent JDBC source connector: a timestamp column to order by, plus an id to break ties within one
+ * timestamp, since a timestamp column is not unique.
+ *
+ * Run it the same way as a [BatchedAsyncEventProcessor]:
+ *
+ * ```
+ * ExponentialBackoff(onFailure = { e, _ -> logger.error(e) }).run { asyncEntityProcessor.processOneBatch() }
+ * ```
+ *
+ * @param safeBoundary the timestamp below which rows are safe to read, which is what stops a slow transaction's rows
+ * committing behind the bookmark and being skipped forever. [SafeBoundary] explains why an `updated_at` column needs
+ * one at all; [PostgresXactStartSafeBoundary] is the implementation to use on Postgres. There is no default because no
+ * one value is safe for every table.
+ * @param stallThreshold how long the [safeBoundary] may hold this processor back before it throws
+ * [SafeBoundaryStalledException] into the caller's [ExponentialBackoff] `onFailure`, and so into error tracking rather
+ * than onto a graph nobody is watching. Null disables the check.
+ * @param clock used only to measure how long a stall has lasted, never to decide which rows are read — the boundary is
+ * database-generated so that no application clock can affect correctness. Reads UTC, like every clock in this API.
+ */
+class BatchedAsyncEntityProcessor<E>(
+    override val entitySource: EntitySource<E>,
+    override val entityUpdatedAtStats: EntityUpdatedAtStats,
+    override val bookmarkStore: EntityBookmarkStore,
+    override val bookmarkName: String,
+    override val entityProcessor: EntityProcessor<E>,
+    private val safeBoundary: SafeBoundary,
+    private val batchSize: Int = 1000,
+    private val stallThreshold: Duration? = Duration.ofHours(1),
+    private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) },
+    private val startLog: (EntityBookmark) -> Unit = { bookmark ->
+        System.out.println("Polling for entities for ${bookmark.name} from position ${bookmark.position}")
+    },
+    private val endLog: (Int, EntityBookmark) -> Unit = { count, bookmark ->
+        if (count > 0 || Random.nextFloat() < 0.01) {
+            System.out.println("Finished processing batch for ${bookmark.name}, $count entities up to position ${bookmark.position}")
+        }
+    },
+    private val stats: EntityStatisticsCollector? = null,
+) : AsyncEntityProcessor<E> {
+
+    fun processOneBatch(): Action {
+        val startBookmark = bookmarkStore.checkoutBookmark(bookmarkName).let {
+            if (it is Left<LockNotObtained>)
+                // try again shortly
+                return Action.Wait
+            else
+                (it as Right).value
+        }
+
+        startLog(startBookmark)
+
+        // Read the boundary before the rows, in its own transaction, so a row committing in between is excluded rather
+        // than skipped. SafeBoundary has the argument, including why merging the two reads is not safe.
+        val safeBefore = safeBoundary.safeBefore()
+
+        val (count, finalBookmark) = entitySource.getAfter(startBookmark.position, safeBefore, batchSize).foldIndexed(
+            0 to startBookmark,
+        ) { index, (_, bookmark), positionedEntity ->
+            validateProgress(bookmark.position, positionedEntity.position)
+            processEntity(positionedEntity)
+            bookmarkStore.save(bookmarkName, positionedEntity.position)
+            index + 1 to bookmark.copy(position = positionedEntity.position)
+        }
+
+        endLog(count, finalBookmark)
+
+        if (count > 0) heldBackSince = null else failIfHeldBackTooLong(safeBefore)
+
+        return if (count >= batchSize) Action.Continue else Action.Wait
+    }
+
+    /** When this processor was first observed making no progress *because of* the boundary. Null when it is not. */
+    private var heldBackSince: LocalDateTime? = null
+
+    /**
+     * Tells "held back by the boundary" from "caught up", which is the whole difficulty here. Staleness of the boundary
+     * cannot be the signal: during a first run over a large table it may sit hours in the past, pinned by an unrelated
+     * transaction, while the processor works through millions of rows perfectly happily — throwing there would abort
+     * the backfill. What discriminates is the head of the table against the boundary. Reading nothing while the newest
+     * row sits at or beyond it means there is work the boundary forbids; reading nothing while the newest row is behind
+     * it means there is nothing to do. Only continuously, too: any batch with rows in it clears the timer.
+     */
+    private fun failIfHeldBackTooLong(safeBefore: LocalDateTime) {
+        val head = entityUpdatedAtStats.lastUpdatedAt()
+        if (head == null || head < safeBefore) {
+            // caught up: everything in the table is already behind the boundary
+            heldBackSince = null
+            return
+        }
+
+        val now = clock()
+        val since = heldBackSince ?: now.also { heldBackSince = it }
+        val heldBackFor = Duration.between(since, now)
+
+        if (stallThreshold != null && heldBackFor > stallThreshold) {
+            throw SafeBoundaryStalledException(
+                "$bookmarkName has been held back by its safe boundary for $heldBackFor, which is longer than the " +
+                    "$stallThreshold threshold. Rows are waiting ($head is at or beyond the boundary of $safeBefore) " +
+                    "but cannot be read until the oldest open transaction ends. Nothing is lost and this recovers on " +
+                    "its own once that happens, so the fix is to end that transaction. " +
+                    safeBoundary.describeBlockers(),
+            )
+        }
+    }
+
+    /**
+     * A source that returns rows out of order, or re-returns the row its bookmark is on, would silently skip rows or
+     * reprocess one forever without the bookmark advancing. A position round-trips exactly, so a source honouring its
+     * `after` predicate cannot trip these.
+     */
+    private fun validateProgress(previous: EntityPosition?, next: EntityPosition) {
+        if (previous == null) return
+        if (next == previous) {
+            throw EntitySourceStalledException(
+                "Entity-source for $bookmarkName returned the row at position $next that its bookmark is already at, " +
+                    "rather than only rows strictly after it, so this row would be re-read forever.",
+            )
+        }
+        if (next.updatedAt < previous.updatedAt) {
+            throw EntitySourceOrderingException(
+                "Entity-source for $bookmarkName returned the row at position $next after the row at position $previous, " +
+                    "but rows must be returned in ascending updated-at order.",
+            )
+        }
+    }
+
+    private fun processEntity(positionedEntity: PositionedEntity<E>) {
+        stats?.let {
+            val startTime = System.currentTimeMillis()
+            entityProcessor.process(positionedEntity.entity, positionedEntity.position)
+            stats.entityProcessed(this, positionedEntity, System.currentTimeMillis() - startTime)
+        } ?: entityProcessor.process(positionedEntity.entity, positionedEntity.position)
+    }
+}
+
+open class EntitySourceException(message: String) : RuntimeException(message)
+class EntitySourceStalledException(message: String) : EntitySourceException(message)
+class EntitySourceOrderingException(message: String) : EntitySourceException(message)
+
+interface EntityStatisticsCollector {
+    fun entityProcessed(processor: AsyncEntityProcessor<*>, entity: PositionedEntity<*>, durationMs: Long)
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
@@ -96,25 +96,9 @@ class BatchedAsyncEntityProcessor<E>(
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
 
-    /**
-     * How much unreadable work has piled up above the boundary: the head of the table against the start time of the
-     * oldest open transaction. Both sides are database-generated and stamped by the same clock — `xact_start` is the
-     * reading `now()` puts into `updated_at` — so no application clock enters this, and clock skew cannot make a stall
-     * appear or disappear.
-     *
-     * That one comparison is also the whole test. A caught-up processor has its newest row *behind* the boundary, which
-     * makes the span negative; an empty table has no row at all; and a boundary pinned hours back with only minutes of
-     * writes above it is not yet worth reporting. Only a genuine backlog of blocked writes exceeds the threshold.
-     *
-     * Called only when a batch read nothing, so a first run over a large table — happily reading millions of rows below
-     * a boundary that an unrelated transaction has pinned hours back — never trips it.
-     */
     private fun reportIfStalled(boundary: SafeBoundaryReading) {
         if (stallThreshold == null) return
 
-        // A row cannot be stamped after the moment the boundary was read, so `head - safeBefore` can never exceed
-        // `readAt - safeBefore`. When the cheap comparison is under the threshold the expensive one cannot be over it,
-        // which keeps the head query off every idle poll without ever missing a stall.
         if (Duration.between(boundary.safeBefore, boundary.readAt) <= stallThreshold) return
 
         val head = entityUpdatedAtStats.lastUpdatedAt() ?: return

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
@@ -3,7 +3,6 @@ package com.cultureamp.eventsourcing
 import com.cultureamp.common.Action
 import java.time.Duration
 import java.time.LocalDateTime
-import java.time.ZoneOffset
 import kotlin.random.Random
 
 interface BookmarkedEntityProcessor<E> {
@@ -41,12 +40,9 @@ interface AsyncEntityProcessor<E> : BookmarkedEntityProcessor<E> {
  *
  * @param safeBoundary the timestamp below which rows are safe to read, which is what stops a slow transaction's rows
  * committing behind the bookmark and being skipped forever.
- * @param stallThreshold how long the oldest open transaction may hold the boundary back before [stallBehaviour] is
- * invoked. Null disables the check.
- * @param stallBehaviour whether a stall throws or is logged; see [StallBehaviour]. Either way the report comes after
- * the batch has been processed and bookmarked, so it never costs progress that was available.
- * @param clock used only to size a stall, never to decide which rows are read — the boundary is database-generated so
- * that no application clock can affect correctness. Reads UTC, like every clock in this API.
+ * @param stallThreshold how far the head of the table may run ahead of the boundary, with nothing readable in between,
+ * before [stallBehaviour] is invoked. Null disables the check.
+ * @param stallBehaviour whether a stall throws or is logged; see [StallBehaviour].
  */
 class BatchedAsyncEntityProcessor<E>(
     override val entitySource: EntitySource<E>,
@@ -58,7 +54,6 @@ class BatchedAsyncEntityProcessor<E>(
     private val batchSize: Int = 1000,
     private val stallThreshold: Duration? = Duration.ofHours(1),
     private val stallBehaviour: StallBehaviour = StallBehaviour.Throw,
-    private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) },
     private val startLog: (EntityBookmark) -> Unit = { bookmark ->
         System.out.println("Polling for entities for ${bookmark.name} from position ${bookmark.position}")
     },
@@ -95,28 +90,34 @@ class BatchedAsyncEntityProcessor<E>(
 
         endLog(count, finalBookmark)
 
-        reportIfStalled(safeBefore)
+        if (count == 0) reportIfStalled(safeBefore)
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
 
     /**
-     * The boundary *is* the start time of the oldest open transaction, or the database's own clock when nothing is
-     * open, so how long that transaction has been holding rows back is just the gap between the boundary and now. No
-     * state to keep and no extra query.
+     * How much unreadable work has piled up above the boundary: the head of the table against the start time of the
+     * oldest open transaction. Both sides are database-generated and stamped by the same clock — `xact_start` is the
+     * reading `now()` puts into `updated_at` — so no application clock enters this, and clock skew cannot make a stall
+     * appear or disappear.
      *
-     * This is the one place an application clock meets a database timestamp, which the row-reading path deliberately
-     * never does. It only sizes a stall against an hour-scale threshold, where seconds of skew do not matter.
+     * That one comparison is also the whole test. A caught-up processor has its newest row *behind* the boundary, which
+     * makes the span negative; an empty table has no row at all; and a boundary pinned hours back with only minutes of
+     * writes above it is not yet worth reporting. Only a genuine backlog of blocked writes exceeds the threshold.
+     *
+     * Called only when a batch read nothing, so a first run over a large table — happily reading millions of rows below
+     * a boundary that an unrelated transaction has pinned hours back — never trips it.
      */
     private fun reportIfStalled(safeBefore: LocalDateTime) {
         if (stallThreshold == null) return
-        val heldBackFor = Duration.between(safeBefore, clock())
-        if (heldBackFor <= stallThreshold) return
+        val head = entityUpdatedAtStats.lastUpdatedAt() ?: return
+        val blockedFor = Duration.between(safeBefore, head)
+        if (blockedFor <= stallThreshold) return
 
-        val message = "$bookmarkName's safe boundary is $heldBackFor behind now, which is longer than the " +
-            "$stallThreshold threshold, because the oldest open transaction in this database has been open at least " +
-            "that long. Rows at or after the boundary of $safeBefore cannot be read until it ends. Nothing is lost " +
-            "and this recovers on its own once that happens, so the fix is to end that transaction. " +
+        val message = "$bookmarkName read nothing and cannot catch up: the newest row in its table ($head) sits " +
+            "$blockedFor beyond the safe boundary of $safeBefore, which is longer than the $stallThreshold threshold. " +
+            "The oldest open transaction in this database is holding the boundary there. Nothing is lost and this " +
+            "recovers on its own once that transaction ends, so the fix is to end it. " +
             safeBoundary.describeBlockers()
 
         when (stallBehaviour) {
@@ -168,9 +169,9 @@ sealed interface StallBehaviour {
     object Throw : StallBehaviour
 
     /**
-     * Report and carry on. The mode for a first run over a large table, where the boundary can legitimately sit hours
-     * in the past — pinned by an unrelated transaction — while millions of rows behind it are read perfectly happily,
-     * and an error every poll would be noise rather than news.
+     * Report and carry on polling, so the stall reaches a log rather than an error tracker. For callers who would
+     * rather see staleness on a dashboard than have every poll raise, and who are watching [EntityLag.latencyMs]
+     * anyway.
      */
     data class LogAndContinue(val log: (String) -> Unit) : StallBehaviour
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
@@ -40,14 +40,13 @@ interface AsyncEntityProcessor<E> : BookmarkedEntityProcessor<E> {
  * ```
  *
  * @param safeBoundary the timestamp below which rows are safe to read, which is what stops a slow transaction's rows
- * committing behind the bookmark and being skipped forever. [SafeBoundary] explains why an `updated_at` column needs
- * one at all; [PostgresXactStartSafeBoundary] is the implementation to use on Postgres. There is no default because no
- * one value is safe for every table.
- * @param stallThreshold how long the [safeBoundary] may hold this processor back before it throws
- * [SafeBoundaryStalledException] into the caller's [ExponentialBackoff] `onFailure`, and so into error tracking rather
- * than onto a graph nobody is watching. Null disables the check.
- * @param clock used only to measure how long a stall has lasted, never to decide which rows are read — the boundary is
- * database-generated so that no application clock can affect correctness. Reads UTC, like every clock in this API.
+ * committing behind the bookmark and being skipped forever.
+ * @param stallThreshold how long the oldest open transaction may hold the boundary back before [stallBehaviour] is
+ * invoked. Null disables the check.
+ * @param stallBehaviour whether a stall throws or is logged; see [StallBehaviour]. Either way the report comes after
+ * the batch has been processed and bookmarked, so it never costs progress that was available.
+ * @param clock used only to size a stall, never to decide which rows are read — the boundary is database-generated so
+ * that no application clock can affect correctness. Reads UTC, like every clock in this API.
  */
 class BatchedAsyncEntityProcessor<E>(
     override val entitySource: EntitySource<E>,
@@ -58,6 +57,7 @@ class BatchedAsyncEntityProcessor<E>(
     private val safeBoundary: SafeBoundary,
     private val batchSize: Int = 1000,
     private val stallThreshold: Duration? = Duration.ofHours(1),
+    private val stallBehaviour: StallBehaviour = StallBehaviour.Throw,
     private val clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) },
     private val startLog: (EntityBookmark) -> Unit = { bookmark ->
         System.out.println("Polling for entities for ${bookmark.name} from position ${bookmark.position}")
@@ -81,8 +81,7 @@ class BatchedAsyncEntityProcessor<E>(
 
         startLog(startBookmark)
 
-        // Read the boundary before the rows, in its own transaction, so a row committing in between is excluded rather
-        // than skipped. SafeBoundary has the argument, including why merging the two reads is not safe.
+        // Read the boundary before the rows, in its own transaction, so a row committing in between is excluded rather than skipped
         val safeBefore = safeBoundary.safeBefore()
 
         val (count, finalBookmark) = entitySource.getAfter(startBookmark.position, safeBefore, batchSize).foldIndexed(
@@ -96,42 +95,33 @@ class BatchedAsyncEntityProcessor<E>(
 
         endLog(count, finalBookmark)
 
-        if (count > 0) heldBackSince = null else failIfHeldBackTooLong(safeBefore)
+        reportIfStalled(safeBefore)
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
 
-    /** When this processor was first observed making no progress *because of* the boundary. Null when it is not. */
-    private var heldBackSince: LocalDateTime? = null
-
     /**
-     * Tells "held back by the boundary" from "caught up", which is the whole difficulty here. Staleness of the boundary
-     * cannot be the signal: during a first run over a large table it may sit hours in the past, pinned by an unrelated
-     * transaction, while the processor works through millions of rows perfectly happily — throwing there would abort
-     * the backfill. What discriminates is the head of the table against the boundary. Reading nothing while the newest
-     * row sits at or beyond it means there is work the boundary forbids; reading nothing while the newest row is behind
-     * it means there is nothing to do. Only continuously, too: any batch with rows in it clears the timer.
+     * The boundary *is* the start time of the oldest open transaction, or the database's own clock when nothing is
+     * open, so how long that transaction has been holding rows back is just the gap between the boundary and now. No
+     * state to keep and no extra query.
+     *
+     * This is the one place an application clock meets a database timestamp, which the row-reading path deliberately
+     * never does. It only sizes a stall against an hour-scale threshold, where seconds of skew do not matter.
      */
-    private fun failIfHeldBackTooLong(safeBefore: LocalDateTime) {
-        val head = entityUpdatedAtStats.lastUpdatedAt()
-        if (head == null || head < safeBefore) {
-            // caught up: everything in the table is already behind the boundary
-            heldBackSince = null
-            return
-        }
+    private fun reportIfStalled(safeBefore: LocalDateTime) {
+        if (stallThreshold == null) return
+        val heldBackFor = Duration.between(safeBefore, clock())
+        if (heldBackFor <= stallThreshold) return
 
-        val now = clock()
-        val since = heldBackSince ?: now.also { heldBackSince = it }
-        val heldBackFor = Duration.between(since, now)
+        val message = "$bookmarkName's safe boundary is $heldBackFor behind now, which is longer than the " +
+            "$stallThreshold threshold, because the oldest open transaction in this database has been open at least " +
+            "that long. Rows at or after the boundary of $safeBefore cannot be read until it ends. Nothing is lost " +
+            "and this recovers on its own once that happens, so the fix is to end that transaction. " +
+            safeBoundary.describeBlockers()
 
-        if (stallThreshold != null && heldBackFor > stallThreshold) {
-            throw SafeBoundaryStalledException(
-                "$bookmarkName has been held back by its safe boundary for $heldBackFor, which is longer than the " +
-                    "$stallThreshold threshold. Rows are waiting ($head is at or beyond the boundary of $safeBefore) " +
-                    "but cannot be read until the oldest open transaction ends. Nothing is lost and this recovers on " +
-                    "its own once that happens, so the fix is to end that transaction. " +
-                    safeBoundary.describeBlockers(),
-            )
+        when (stallBehaviour) {
+            is StallBehaviour.Throw -> throw SafeBoundaryStalledException(message)
+            is StallBehaviour.LogAndContinue -> stallBehaviour.log(message)
         }
     }
 
@@ -163,6 +153,26 @@ class BatchedAsyncEntityProcessor<E>(
             stats.entityProcessed(this, positionedEntity, System.currentTimeMillis() - startTime)
         } ?: entityProcessor.process(positionedEntity.entity, positionedEntity.position)
     }
+}
+
+/**
+ * What a [BatchedAsyncEntityProcessor] does once its `safeBoundary` has been holding rows back for longer than its
+ * `stallThreshold`. Both modes report the same message, which names the sessions to go and close.
+ */
+sealed interface StallBehaviour {
+    /**
+     * Throw [SafeBoundaryStalledException], so the caller's [ExponentialBackoff] `onFailure` puts it in front of
+     * somebody with a stacktrace. The default: a processor publishing nothing for hours is the problem the boundary
+     * exists to remove, and it should not be left to be noticed on a graph.
+     */
+    object Throw : StallBehaviour
+
+    /**
+     * Report and carry on. The mode for a first run over a large table, where the boundary can legitimately sit hours
+     * in the past — pinned by an unrelated transaction — while millions of rows behind it are read perfectly happily,
+     * and an error every poll would be noise rather than news.
+     */
+    data class LogAndContinue(val log: (String) -> Unit) : StallBehaviour
 }
 
 open class EntitySourceException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessor.kt
@@ -2,7 +2,6 @@ package com.cultureamp.eventsourcing
 
 import com.cultureamp.common.Action
 import java.time.Duration
-import java.time.LocalDateTime
 import kotlin.random.Random
 
 interface BookmarkedEntityProcessor<E> {
@@ -41,7 +40,9 @@ interface AsyncEntityProcessor<E> : BookmarkedEntityProcessor<E> {
  * @param safeBoundary the timestamp below which rows are safe to read, which is what stops a slow transaction's rows
  * committing behind the bookmark and being skipped forever.
  * @param stallThreshold how far the head of the table may run ahead of the boundary, with nothing readable in between,
- * before [stallBehaviour] is invoked. Null disables the check.
+ * before [stallBehaviour] is invoked. Null disables the check. Note this measures a backlog of blocked writes rather
+ * than elapsed time, so a table that stops being written to stops accruing it — [AsyncEntityProcessorMonitor]'s
+ * `latencyMs` is what keeps growing regardless, and is the better thing to alert on.
  * @param stallBehaviour whether a stall throws or is logged; see [StallBehaviour].
  */
 class BatchedAsyncEntityProcessor<E>(
@@ -77,9 +78,9 @@ class BatchedAsyncEntityProcessor<E>(
         startLog(startBookmark)
 
         // Read the boundary before the rows, in its own transaction, so a row committing in between is excluded rather than skipped
-        val safeBefore = safeBoundary.safeBefore()
+        val boundary = safeBoundary.read()
 
-        val (count, finalBookmark) = entitySource.getAfter(startBookmark.position, safeBefore, batchSize).foldIndexed(
+        val (count, finalBookmark) = entitySource.getAfter(startBookmark.position, boundary.safeBefore, batchSize).foldIndexed(
             0 to startBookmark,
         ) { index, (_, bookmark), positionedEntity ->
             validateProgress(bookmark.position, positionedEntity.position)
@@ -90,7 +91,7 @@ class BatchedAsyncEntityProcessor<E>(
 
         endLog(count, finalBookmark)
 
-        if (count == 0) reportIfStalled(safeBefore)
+        if (count == 0) reportIfStalled(boundary)
 
         return if (count >= batchSize) Action.Continue else Action.Wait
     }
@@ -108,16 +109,22 @@ class BatchedAsyncEntityProcessor<E>(
      * Called only when a batch read nothing, so a first run over a large table — happily reading millions of rows below
      * a boundary that an unrelated transaction has pinned hours back — never trips it.
      */
-    private fun reportIfStalled(safeBefore: LocalDateTime) {
+    private fun reportIfStalled(boundary: SafeBoundaryReading) {
         if (stallThreshold == null) return
+
+        // A row cannot be stamped after the moment the boundary was read, so `head - safeBefore` can never exceed
+        // `readAt - safeBefore`. When the cheap comparison is under the threshold the expensive one cannot be over it,
+        // which keeps the head query off every idle poll without ever missing a stall.
+        if (Duration.between(boundary.safeBefore, boundary.readAt) <= stallThreshold) return
+
         val head = entityUpdatedAtStats.lastUpdatedAt() ?: return
-        val blockedFor = Duration.between(safeBefore, head)
+        val blockedFor = Duration.between(boundary.safeBefore, head)
         if (blockedFor <= stallThreshold) return
 
         val message = "$bookmarkName read nothing and cannot catch up: the newest row in its table ($head) sits " +
-            "$blockedFor beyond the safe boundary of $safeBefore, which is longer than the $stallThreshold threshold. " +
-            "The oldest open transaction in this database is holding the boundary there. Nothing is lost and this " +
-            "recovers on its own once that transaction ends, so the fix is to end it. " +
+            "$blockedFor beyond the safe boundary of ${boundary.safeBefore}, which is longer than the " +
+            "$stallThreshold threshold. The oldest open transaction in this database is holding the boundary there. " +
+            "Nothing is lost and this recovers on its own once that transaction ends, so the fix is to end it. " +
             safeBoundary.describeBlockers()
 
         when (stallBehaviour) {

--- a/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
@@ -69,7 +69,7 @@ class RelationalDatabaseBookmarkStore(
     private fun isExists(bookmarkName: String) = !rowsForBookmarks(setOf(bookmarkName)).empty()
 }
 
-private fun createPGSessionLock(db: Database) = PGSessionAdvisoryBookmarkLock {
+internal fun createPGSessionLock(db: Database) = PGSessionAdvisoryBookmarkLock {
     db.connector().connection.let {
         it as? Connection ?: throw RuntimeException("Got a connection of an unknown type: $it")
     }
@@ -91,10 +91,17 @@ interface BookmarkLock : Closeable {
      * @return true If the lock is now held (whether it was freshly obtained or not), false otherwise
      */
     fun tryLock(bookmark: Bookmark): Boolean
+
+    /**
+     * Attempts to acquire the lock for the bookmark of this name. Locking only ever cares about the name, so this is
+     * the form used by stores whose bookmarks aren't sequence-based, e.g. [EntityBookmarkStore].
+     */
+    fun tryLock(bookmarkName: String): Boolean = tryLock(Bookmark(bookmarkName, 0))
 }
 
 object NoOpBookmarkLock: BookmarkLock {
     override fun tryLock(bookmark: Bookmark) = true
+    override fun tryLock(bookmarkName: String) = true
     override fun close() = Unit
 }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
@@ -86,7 +86,7 @@ class RelationalDatabaseEntityBookmarkStore(
 class EntityBookmarks(tableName: String = defaultEntityBookmarksTableName) : Table(tableName) {
     val name = varchar("name", 160)
 
-    /** Naive, like the source column a position is read from, so a position is stored exactly as it was read. */
+    /** Naive and holding UTC, like every timestamp here and the source column a position is read from. */
     val entityLastUpdatedAt = datetime("entity_last_updated_at")
     val entityLastId = javaUUID("entity_last_id")
     val bookmarkCreatedAt = datetime("bookmark_created_at")

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
@@ -23,11 +23,6 @@ interface EntityBookmarkStore {
     fun bookmarkFor(bookmarkName: String): EntityBookmark
     fun bookmarksFor(bookmarkNames: Set<String>): Set<EntityBookmark>
 
-    /**
-     * Records progress for a bookmark. Takes a position rather than an [EntityBookmark] because a stored bookmark
-     * always sits on a row it has processed: "nothing processed yet" is the absence of a bookmark, so there is nothing
-     * to save.
-     */
     fun save(bookmarkName: String, position: EntityPosition)
 
     /**
@@ -66,16 +61,16 @@ class RelationalDatabaseEntityBookmarkStore(
         if (!isExists(bookmarkName)) {
             table.insert {
                 it[name] = bookmarkName
-                it[lastUpdatedAt] = position.updatedAt
-                it[lastId] = position.id
-                it[createdAt] = nowUtc()
-                it[updatedAt] = nowUtc()
+                it[entityLastUpdatedAt] = position.updatedAt
+                it[entityLastId] = position.id
+                it[bookmarkCreatedAt] = nowUtc()
+                it[bookmarkUpdatedAt] = nowUtc()
             }
         } else {
             table.update({ table.name eq bookmarkName }) {
-                it[lastUpdatedAt] = position.updatedAt
-                it[lastId] = position.id
-                it[updatedAt] = nowUtc()
+                it[entityLastUpdatedAt] = position.updatedAt
+                it[entityLastId] = position.id
+                it[bookmarkUpdatedAt] = nowUtc()
             }
         }
     }
@@ -86,7 +81,7 @@ class RelationalDatabaseEntityBookmarkStore(
         }
     }
 
-    private fun ResultRow.toPosition() = EntityPosition(this[table.lastUpdatedAt], this[table.lastId])
+    private fun ResultRow.toPosition() = EntityPosition(this[table.entityLastUpdatedAt], this[table.entityLastId])
 
     private fun rowsForBookmarks(bookmarkNames: Set<String>) = table.selectAll().where { table.name.inList(bookmarkNames) }
     private fun isExists(bookmarkName: String) = !rowsForBookmarks(setOf(bookmarkName)).empty()
@@ -96,10 +91,10 @@ class EntityBookmarks(tableName: String = defaultEntityBookmarksTableName) : Tab
     val name = varchar("name", 160)
 
     /** Naive, like the source column a position is read from, so a position is stored exactly as it was read. */
-    val lastUpdatedAt = datetime("last_updated_at")
-    val lastId = javaUUID("last_id")
-    val createdAt = datetime("created_at")
-    val updatedAt = datetime("updated_at")
+    val entityLastUpdatedAt = datetime("entity_last_updated_at")
+    val entityLastId = javaUUID("entity_last_id")
+    val bookmarkCreatedAt = datetime("bookmark_created_at")
+    val bookmarkUpdatedAt = datetime("bookmark_updated_at")
     override val primaryKey = PrimaryKey(name)
 }
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
@@ -1,0 +1,113 @@
+package com.cultureamp.eventsourcing
+
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.core.vendors.PostgreSQLDialect
+import org.jetbrains.exposed.v1.javatime.datetime
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+val defaultEntityBookmarksTableName = "entity_bookmarks"
+
+/** Stores the [EntityPosition] of the last processed row for an [EntityProcessor], analogous to [BookmarkStore]. */
+interface EntityBookmarkStore {
+    fun bookmarkFor(bookmarkName: String): EntityBookmark
+    fun bookmarksFor(bookmarkNames: Set<String>): Set<EntityBookmark>
+
+    /**
+     * Records progress for a bookmark. Takes a position rather than an [EntityBookmark] because a stored bookmark
+     * always sits on a row it has processed: "nothing processed yet" is the absence of a bookmark, so there is nothing
+     * to save.
+     */
+    fun save(bookmarkName: String, position: EntityPosition)
+
+    /**
+     * Finds the bookmark of this name and attempts to lock it, returning it if the lock is obtained or retained.
+     */
+    fun checkoutBookmark(bookmarkName: String): Either<LockNotObtained, EntityBookmark>
+}
+
+/**
+ * Note that bookmark locking shares a key-space with [RelationalDatabaseBookmarkStore], so an entity-bookmark and an
+ * event-bookmark of the same name will lock each other out. Give them distinct names.
+ */
+class RelationalDatabaseEntityBookmarkStore(
+    val db: Database,
+    val table: EntityBookmarks = EntityBookmarks(),
+    private val bookmarkLock: BookmarkLock = if (db.dialect is PostgreSQLDialect) createPGSessionLock(db) else NoOpBookmarkLock,
+) : EntityBookmarkStore {
+    override fun bookmarkFor(bookmarkName: String): EntityBookmark = bookmarksFor(setOf(bookmarkName)).first()
+
+    override fun checkoutBookmark(bookmarkName: String): Either<LockNotObtained, EntityBookmark> =
+        bookmarkFor(bookmarkName).let {
+            if (bookmarkLock.tryLock(it.name))
+                Right(it)
+            else
+                Left(LockNotObtained)
+        }
+
+    override fun bookmarksFor(bookmarkNames: Set<String>): Set<EntityBookmark> = transaction(db) {
+        val matchingRows = rowsForBookmarks(bookmarkNames)
+        val foundBookmarks = matchingRows.map { EntityBookmark(it[table.name], it.toPosition()) }.toSet()
+        val emptyBookmarks = (bookmarkNames - foundBookmarks.map { it.name }.toSet()).map { EntityBookmark(it, null) }.toSet()
+        foundBookmarks + emptyBookmarks
+    }
+
+    override fun save(bookmarkName: String, position: EntityPosition): Unit = transaction(db) {
+        if (!isExists(bookmarkName)) {
+            table.insert {
+                it[name] = bookmarkName
+                it[lastUpdatedAt] = position.updatedAt
+                it[lastId] = position.id
+                it[createdAt] = nowUtc()
+                it[updatedAt] = nowUtc()
+            }
+        } else {
+            table.update({ table.name eq bookmarkName }) {
+                it[lastUpdatedAt] = position.updatedAt
+                it[lastId] = position.id
+                it[updatedAt] = nowUtc()
+            }
+        }
+    }
+
+    fun createSchemaIfNotExists() {
+        transaction(db) {
+            SchemaUtils.create(table)
+        }
+    }
+
+    private fun ResultRow.toPosition() = EntityPosition(this[table.lastUpdatedAt], this[table.lastId])
+
+    private fun rowsForBookmarks(bookmarkNames: Set<String>) = table.selectAll().where { table.name.inList(bookmarkNames) }
+    private fun isExists(bookmarkName: String) = !rowsForBookmarks(setOf(bookmarkName)).empty()
+}
+
+class EntityBookmarks(tableName: String = defaultEntityBookmarksTableName) : Table(tableName) {
+    val name = varchar("name", 160)
+
+    /** Naive, like the source column a position is read from, so a position is stored exactly as it was read. */
+    val lastUpdatedAt = datetime("last_updated_at")
+    val lastId = javaUUID("last_id")
+    val createdAt = datetime("created_at")
+    val updatedAt = datetime("updated_at")
+    override val primaryKey = PrimaryKey(name)
+}
+
+/**
+ * A null [position] means nothing has been processed yet and the processor starts from the beginning of the table, the
+ * equivalent of a [Bookmark] with sequence `0`. The stored columns are not nullable — a row only exists once something
+ * has been processed — so the null lives in this type rather than in the table.
+ */
+data class EntityBookmark(val name: String, val position: EntityPosition?)
+
+private fun nowUtc(): LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityBookmarkStore.kt
@@ -31,10 +31,6 @@ interface EntityBookmarkStore {
     fun checkoutBookmark(bookmarkName: String): Either<LockNotObtained, EntityBookmark>
 }
 
-/**
- * Note that bookmark locking shares a key-space with [RelationalDatabaseBookmarkStore], so an entity-bookmark and an
- * event-bookmark of the same name will lock each other out. Give them distinct names.
- */
 class RelationalDatabaseEntityBookmarkStore(
     val db: Database,
     val table: EntityBookmarks = EntityBookmarks(),
@@ -44,7 +40,7 @@ class RelationalDatabaseEntityBookmarkStore(
 
     override fun checkoutBookmark(bookmarkName: String): Either<LockNotObtained, EntityBookmark> =
         bookmarkFor(bookmarkName).let {
-            if (bookmarkLock.tryLock(it.name))
+            if (bookmarkLock.tryLock(lockNamespace + it.name))
                 Right(it)
             else
                 Left(LockNotObtained)
@@ -106,3 +102,16 @@ class EntityBookmarks(tableName: String = defaultEntityBookmarksTableName) : Tab
 data class EntityBookmark(val name: String, val position: EntityPosition?)
 
 private fun nowUtc(): LocalDateTime = LocalDateTime.now(ZoneOffset.UTC)
+
+/**
+ * Keeps entity-bookmark locks out of the event-bookmark key-space. [PGSessionAdvisoryBookmarkLock] hashes the name it
+ * is given into a `pg_try_advisory_lock` key, and advisory locks are one flat per-database space of integers with no
+ * notion of which table a bookmark lives in — so without this, an entity-bookmark and an event-bookmark sharing a name
+ * would compete for one lock. The loser would then get [LockNotObtained] on every poll for the life of the process,
+ * silently, because these locks are session-level and held until the connection closes.
+ *
+ * Only this side is namespaced. Adding a prefix to [RelationalDatabaseBookmarkStore] would change the key an already
+ * deployed event-processor computes, so during a rolling deploy the old and new instances would hold different locks
+ * and both process at once — which is the thing the lock exists to prevent.
+ */
+private const val lockNamespace = "entity:"

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityProcessor.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityProcessor.kt
@@ -1,0 +1,39 @@
+package com.cultureamp.eventsourcing
+
+/**
+ * Processes entities read from an [EntitySource], analogous to an [EventProcessor].
+ *
+ * As with event-processors, implementations should be idempotent and re-runnable from the beginning of the stream,
+ * since delivery is at-least-once: a row can be delivered more than once if a processor dies after processing it but
+ * before its bookmark is saved, and it will be delivered again every time it is touched (its `updated_at` moves).
+ *
+ * Note that, unlike an event stream, an entity table only ever exposes the *current* state of a row. A row updated
+ * twice in quick succession may only be seen once, and rows are seen in `updated_at` order rather than in the order
+ * they were created.
+ */
+interface EntityProcessor<in E> {
+    fun process(entity: E, position: EntityPosition)
+
+    companion object {
+        fun <E> from(process: (E) -> Any?) = object : EntityProcessor<E> {
+            override fun process(entity: E, position: EntityPosition) {
+                process(entity)
+            }
+        }
+
+        fun <E> from(process: (E, EntityPosition) -> Any?) = object : EntityProcessor<E> {
+            override fun process(entity: E, position: EntityPosition) {
+                process(entity, position)
+            }
+        }
+
+        /**
+         * Wraps several entity-processors up as one, so that they can share a single bookmark.
+         */
+        fun <E> compose(first: EntityProcessor<E>, vararg remainder: EntityProcessor<E>) = CompositeEntityProcessor(listOf(first) + remainder)
+    }
+}
+
+class CompositeEntityProcessor<in E>(private val entityProcessors: List<EntityProcessor<E>>) : EntityProcessor<E> {
+    override fun process(entity: E, position: EntityPosition) = entityProcessors.forEach { it.process(entity, position) }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
@@ -47,9 +47,7 @@ data class PositionedEntity<out E>(val entity: E, val position: EntityPosition)
  * 1. Return only rows strictly after [after] in `(updatedAt, id)` order, i.e.
  *    `updated_at > after.updatedAt OR (updated_at = after.updatedAt AND id > after.id)`. A null [after] means "from
  *    the very beginning".
- * 2. Return only rows with `updated_at < safeBefore`. **Strictly** less than: the boundary a [SafeBoundary] reports is
- *    exclusive, because with `now()`-stamped timestamps the rows most needing to be excluded — those of the oldest open
- *    transaction — sit on it exactly.
+ * 2. Return only rows with `updated_at < safeBefore`. See [SafeBoundary] for more detail on why this is necessary.
  * 3. Return rows ordered ascending by `(updated_at, id)`, at most [batchSize] of them.
  *
  * A [LocalDateTime] is nanosecond-precision, so it round-trips a `timestamp` exactly and a bookmark saved from a row
@@ -67,12 +65,6 @@ interface EntitySource<out E> {
         /** Builds an [EntitySource] from a repository function that already knows how to position its rows. */
         fun <E> from(fetch: (EntityPosition?, LocalDateTime, Int) -> List<PositionedEntity<E>>) = object : EntitySource<E> {
             override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int) = fetch(after, safeBefore, batchSize)
-        }
-
-        /** Builds an [EntitySource] from plain entities, deriving each row's position via [positionOf]. */
-        fun <E> from(positionOf: (E) -> EntityPosition, fetch: (EntityPosition?, LocalDateTime, Int) -> List<E>) = object : EntitySource<E> {
-            override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int) =
-                fetch(after, safeBefore, batchSize).map { PositionedEntity(it, positionOf(it)) }
         }
     }
 }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
@@ -56,7 +56,7 @@ data class PositionedEntity<out E>(val entity: E, val position: EntityPosition)
  * and fails loudly rather than spinning silently.
  *
  * A source must not compute `safeBefore` for itself: the boundary has to be established before the snapshot the rows
- * are read with, which is why [BatchedAsyncEntityProcessor] passes it in. [SafeBoundary] explains why.
+ * are read with, which is why [BatchedAsyncEntityProcessor] reads it from a [SafeBoundary] and passes it in.
  */
 interface EntitySource<out E> {
     fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int = 100): List<PositionedEntity<E>>

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntitySource.kt
@@ -1,0 +1,78 @@
+package com.cultureamp.eventsourcing
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * The position of an entity row in the "updated-at stream" of a table, analogous to the global `sequence` of an
+ * [Event] in the event-store.
+ *
+ * Because an `updated_at` column is not unique, the entity `id` is used as a tiebreaker, giving a total ordering of
+ * `(updatedAt, id)`. This mirrors the "timestamp+incrementing" mode of the Confluent JDBC source connector
+ * ([Incremental Query Modes](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/overview.html#incremental-query-modes)).
+ *
+ * [updatedAt] is a [LocalDateTime] read from a `timestamp without time zone` column and carried around unconverted, so
+ * a position means whatever the column holds. Kestrel's convention, here as in the events table, is that it holds UTC:
+ * nothing in this API converts between zones, so a column stamped in local time would be compared against a UTC
+ * boundary and every timestamp here would be wrong by the offset. Its natural equality agrees with [compareTo], which
+ * is what bookmarks are compared on.
+ *
+ * [compareTo] compares `updatedAt`, then `id` as an *unsigned* 128-bit value, matching how Postgres orders the `uuid`
+ * type. Databases that order UUIDs as signed (H2, for one) disagree with it for positions sharing an `updatedAt`, which
+ * is harmless: ordering rows within a batch is always the database's job (see [EntitySource]), and this ordering only
+ * answers "has a processor caught up?".
+ */
+data class EntityPosition(val updatedAt: LocalDateTime, val id: UUID) : Comparable<EntityPosition> {
+    override fun compareTo(other: EntityPosition): Int {
+        val byUpdatedAt = updatedAt.compareTo(other.updatedAt)
+        return if (byUpdatedAt != 0) byUpdatedAt else id.compareUnsigned(other.id)
+    }
+}
+
+private fun UUID.compareUnsigned(other: UUID): Int {
+    val byMostSignificant = java.lang.Long.compareUnsigned(mostSignificantBits, other.mostSignificantBits)
+    return if (byMostSignificant != 0) byMostSignificant else java.lang.Long.compareUnsigned(leastSignificantBits, other.leastSignificantBits)
+}
+
+/** An entity along with its [EntityPosition], analogous to a [SequencedEvent]. */
+data class PositionedEntity<out E>(val entity: E, val position: EntityPosition)
+
+/**
+ * Reads entities from some table in `(updated_at, id)` order, analogous to an [EventSource] reading events in
+ * `sequence` order.
+ *
+ * Implementations must honour the following contract, since [BatchedAsyncEntityProcessor] relies on it to avoid
+ * skipping or infinitely reprocessing rows:
+ *
+ * 1. Return only rows strictly after [after] in `(updatedAt, id)` order, i.e.
+ *    `updated_at > after.updatedAt OR (updated_at = after.updatedAt AND id > after.id)`. A null [after] means "from
+ *    the very beginning".
+ * 2. Return only rows with `updated_at < safeBefore`. **Strictly** less than: the boundary a [SafeBoundary] reports is
+ *    exclusive, because with `now()`-stamped timestamps the rows most needing to be excluded — those of the oldest open
+ *    transaction — sit on it exactly.
+ * 3. Return rows ordered ascending by `(updated_at, id)`, at most [batchSize] of them.
+ *
+ * A [LocalDateTime] is nanosecond-precision, so it round-trips a `timestamp` exactly and a bookmark saved from a row
+ * selects strictly past that row next time whatever the column's precision. A source that breaks the contract anyway
+ * would stall or skip rows, so [BatchedAsyncEntityProcessor] checks each row against the bookmark it is advancing from
+ * and fails loudly rather than spinning silently.
+ *
+ * A source must not compute `safeBefore` for itself: the boundary has to be established before the snapshot the rows
+ * are read with, which is why [BatchedAsyncEntityProcessor] passes it in. [SafeBoundary] explains why.
+ */
+interface EntitySource<out E> {
+    fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int = 100): List<PositionedEntity<E>>
+
+    companion object {
+        /** Builds an [EntitySource] from a repository function that already knows how to position its rows. */
+        fun <E> from(fetch: (EntityPosition?, LocalDateTime, Int) -> List<PositionedEntity<E>>) = object : EntitySource<E> {
+            override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int) = fetch(after, safeBefore, batchSize)
+        }
+
+        /** Builds an [EntitySource] from plain entities, deriving each row's position via [positionOf]. */
+        fun <E> from(positionOf: (E) -> EntityPosition, fetch: (EntityPosition?, LocalDateTime, Int) -> List<E>) = object : EntitySource<E> {
+            override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int) =
+                fetch(after, safeBefore, batchSize).map { PositionedEntity(it, positionOf(it)) }
+        }
+    }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/EntityUpdatedAtStats.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/EntityUpdatedAtStats.kt
@@ -1,0 +1,18 @@
+package com.cultureamp.eventsourcing
+
+import java.time.LocalDateTime
+
+/**
+ * Reports the head of an entity table's "updated-at stream", i.e. the largest `updated_at` of any row, or null when the
+ * table is empty. The [EntityPosition] equivalent of [EventsSequenceStats], so that [AsyncEntityProcessorMonitor] can
+ * work out how far behind the head a bookmark is.
+ */
+interface EntityUpdatedAtStats {
+    fun lastUpdatedAt(): LocalDateTime?
+
+    companion object {
+        fun from(fetch: () -> LocalDateTime?) = object : EntityUpdatedAtStats {
+            override fun lastUpdatedAt() = fetch()
+        }
+    }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/PGSessionAdvisoryBookmarkLock.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/PGSessionAdvisoryBookmarkLock.kt
@@ -18,15 +18,17 @@ class PGSessionAdvisoryBookmarkLock(
      */
     private var locksHeld = mutableSetOf<String>()
 
-    override fun tryLock(bookmark: Bookmark): Boolean {
+    override fun tryLock(bookmark: Bookmark): Boolean = tryLock(bookmark.name)
+
+    override fun tryLock(bookmarkName: String): Boolean {
         synchronized(mutex) {
             try {
-                return refreshLock(connection, bookmark.name)
+                return refreshLock(connection, bookmarkName)
             } catch (e: SQLException) {
-                logger.info("Failed to refresh session lock for ${bookmark.name}, resetting connection to try again", e)
+                logger.info("Failed to refresh session lock for $bookmarkName, resetting connection to try again", e)
                 close()
                 connection = getConnection()
-                return refreshLock(connection, bookmark.name)
+                return refreshLock(connection, bookmarkName)
             }
         }
     }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
@@ -1,0 +1,73 @@
+package com.cultureamp.eventsourcing
+
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.less
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * An [EntitySource] over any table with an `updated_at`-style timestamp column and a `uuid` identifier, analogous to
+ * [RelationalDatabaseEventStore] on the event-sourcing side. It also implements [EntityUpdatedAtStats], so the same
+ * object can be handed to [AsyncEntityProcessorMonitor] for lag monitoring.
+ *
+ * For this to perform, the table wants an index on `(updatedAtColumn, idColumn)`.
+ *
+ * @param updatedAtColumn the column that advances whenever a row changes. Rows are read in `(updatedAt, id)` order, so
+ * it must never move backwards for a row already read, or that update is missed. Map it with Exposed's `datetime`: it
+ * is a `timestamp without time zone` holding UTC, read and written unconverted (see [EntityPosition]).
+ * @param idColumn the tiebreaker column, used to give rows sharing an updated-at value a stable total ordering.
+ * @param filter an optional additional predicate, applied to both reads and the [lastUpdatedAt] head calculation.
+ * @param rowToEntity maps a row to whatever the [EntityProcessor] wants to consume.
+ */
+class RelationalDatabaseEntitySource<E>(
+    private val db: Database,
+    private val table: Table,
+    private val updatedAtColumn: Column<LocalDateTime>,
+    private val idColumn: Column<UUID>,
+    private val filter: () -> Op<Boolean> = { Op.TRUE },
+    private val rowToEntity: (ResultRow) -> E,
+) : EntitySource<E>, EntityUpdatedAtStats {
+
+    override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int): List<PositionedEntity<E>> {
+        val afterPosition = if (after != null) {
+            (updatedAtColumn greater after.updatedAt) or ((updatedAtColumn eq after.updatedAt) and (idColumn greater after.id))
+        } else {
+            Op.TRUE
+        }
+        // Strictly less than, never `<=`: every row of the oldest open transaction sits at exactly its xact_start,
+        // which is exactly the boundary, so `<=` would admit the whole transaction the boundary exists to exclude.
+        val predicate = afterPosition and (updatedAtColumn less safeBefore) and filter()
+        return transaction(db) {
+            table
+                .selectAll()
+                .where(predicate)
+                .orderBy(updatedAtColumn to SortOrder.ASC, idColumn to SortOrder.ASC)
+                .limit(batchSize)
+                .map { row -> PositionedEntity(rowToEntity(row), EntityPosition(row[updatedAtColumn], row[idColumn])) }
+        }
+    }
+
+    override fun lastUpdatedAt(): LocalDateTime? {
+        return transaction(db) {
+            table
+                .select(updatedAtColumn)
+                .where(filter())
+                .orderBy(updatedAtColumn, SortOrder.DESC)
+                .limit(1)
+                .map { row -> row[updatedAtColumn] }
+                .firstOrNull()
+        }
+    }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
@@ -46,8 +46,6 @@ class RelationalDatabaseEntitySource<E>(
         } else {
             Op.TRUE
         }
-        // Strictly less than, never `<=`: every row of the oldest open transaction sits at exactly its xact_start,
-        // which is exactly the boundary, so `<=` would admit the whole transaction the boundary exists to exclude.
         val predicate = afterPosition and (updatedAtColumn less safeBefore) and filter()
         return transaction(db) {
             table

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
@@ -29,7 +29,9 @@ import java.util.UUID
  * is a `timestamp without time zone` holding UTC, read and written unconverted (see [EntityPosition]). Kestrel never
  * writes it — see the README on maintaining it, since what stamps it decides whether [SafeBoundary] can be sound.
  * @param idColumn the tiebreaker column, used to give rows sharing an updated-at value a stable total ordering.
- * @param filter an optional additional predicate, applied to both reads and the [lastUpdatedAt] head calculation.
+ * @param filter an optional additional predicate, applied to both reads and the [lastUpdatedAt] head calculation. Note
+ * that a row this excludes does not disappear from the projection, it stops being updated in it — so do not filter on a
+ * soft-delete flag if the projection publishes deletions, because a soft delete is the only way one can be seen at all.
  * @param rowToEntity maps a row to whatever the [EntityProcessor] wants to consume.
  */
 class RelationalDatabaseEntitySource<E>(

--- a/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySource.kt
@@ -26,7 +26,8 @@ import java.util.UUID
  *
  * @param updatedAtColumn the column that advances whenever a row changes. Rows are read in `(updatedAt, id)` order, so
  * it must never move backwards for a row already read, or that update is missed. Map it with Exposed's `datetime`: it
- * is a `timestamp without time zone` holding UTC, read and written unconverted (see [EntityPosition]).
+ * is a `timestamp without time zone` holding UTC, read and written unconverted (see [EntityPosition]). Kestrel never
+ * writes it — see the README on maintaining it, since what stamps it decides whether [SafeBoundary] can be sound.
  * @param idColumn the tiebreaker column, used to give rows sharing an updated-at value a stable total ordering.
  * @param filter an optional additional predicate, applied to both reads and the [lastUpdatedAt] head calculation.
  * @param rowToEntity maps a row to whatever the [EntityProcessor] wants to consume.

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -43,6 +43,9 @@ fun interface SafeBoundary {
          *
          * [clock] has to read the same wall-clock that stamps the polled column, so the default reads UTC. The JVM's
          * zone would offset the hold-back, cancelling it east of UTC and stalling reads for hours west of it.
+         *
+         * Note that this boundary sits exactly [delay] behind now at all times, so a [BatchedAsyncEntityProcessor]
+         * using it needs a `stallThreshold` longer than [delay] — otherwise every poll reports a stall.
          */
         fun unsafeFixedDelay(delay: Duration, clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) }) =
             SafeBoundary { clock().minus(delay) }
@@ -153,8 +156,10 @@ class PostgresXactStartSafeBoundary(
         }
     }
 
-    override fun safeBefore(): LocalDateTime {
-        val observation = transaction(db) {
+    override fun safeBefore(): LocalDateTime = observe().validated()
+
+    private fun observe(): Observation {
+        return transaction(db) {
             // A pg_stat_activity read is cached for the whole transaction — pgstat_read_current_status() returns early
             // once the snapshot is populated, and it is discarded only at transaction end. Clearing it first means
             // BOUNDARY_SQL's own read populates it, which is what the statement_timestamp() cap below relies on.
@@ -168,28 +173,35 @@ class PostgresXactStartSafeBoundary(
                 )
             }
         } ?: throw SafeBoundaryException("Reading the safe boundary produced no result")
-
-        if (observation.maxPreparedTransactions != 0) {
-            throw SafeBoundaryUnsupportedException(
-                "max_prepared_transactions is ${observation.maxPreparedTransactions}, but a prepared transaction is not " +
-                    "an ordinary backend in pg_stat_activity and so cannot be seen by this boundary. Set it to 0, or " +
-                    "position rows by commit order instead.",
-            )
-        }
-
-        if (observation.redactedBackends != 0) {
-            throw SafeBoundaryUnreliableException(
-                "${observation.redactedBackends} backend(s) attached to this database are hidden from this connection " +
-                    "in pg_stat_activity, so min(xact_start) is incomplete and rows committed by those backends could " +
-                    "be skipped silently. Grant pg_read_all_stats to this role, or run every writer under a role this " +
-                    "one is a member of.",
-            )
-        }
-
-        return observation.boundary
     }
 
-    private data class Observation(val boundary: LocalDateTime, val redactedBackends: Int, val maxPreparedTransactions: Int)
+    /**
+     * The three readings [BOUNDARY_SQL] returns. Separate from the query so that the two refusals below can be tested
+     * without a database configured to provoke them: `max_prepared_transactions` in particular is a server-level
+     * setting that cannot be changed per session.
+     */
+    internal data class Observation(val boundary: LocalDateTime, val redactedBackends: Int, val maxPreparedTransactions: Int) {
+        fun validated(): LocalDateTime {
+            if (maxPreparedTransactions != 0) {
+                throw SafeBoundaryUnsupportedException(
+                    "max_prepared_transactions is $maxPreparedTransactions, but a prepared transaction is not " +
+                        "an ordinary backend in pg_stat_activity and so cannot be seen by this boundary. Set it to 0, or " +
+                        "position rows by commit order instead.",
+                )
+            }
+
+            if (redactedBackends != 0) {
+                throw SafeBoundaryUnreliableException(
+                    "$redactedBackends backend(s) attached to this database are hidden from this connection " +
+                        "in pg_stat_activity, so min(xact_start) is incomplete and rows committed by those backends could " +
+                        "be skipped silently. Grant pg_read_all_stats to this role, or run every writer under a role this " +
+                        "one is a member of.",
+                )
+            }
+
+            return boundary
+        }
+    }
 
     private companion object {
         /**

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -15,14 +15,14 @@ import java.time.ZoneOffset
  * after the timestamp they carry. A reader whose bookmark has meanwhile passed 12:00 — which ordinary concurrent
  * traffic will do for it — never sees those rows again, with no error and nothing to alert on.
  *
- * The boundary is **exclusive**: only rows with `updated_at < safeBefore()` may be read. It is compared directly
- * against the polled column, so it is a UTC [LocalDateTime] like an [EntityPosition], and an implementation reading it
- * from a database must convert explicitly rather than relying on the session time-zone.
+ * The boundary is **exclusive**: only rows with `updated_at < safeBefore` may be read. It is compared directly against
+ * the polled column, so it is a UTC [LocalDateTime] like an [EntityPosition], and an implementation reading it from a
+ * database must convert explicitly rather than relying on the session time-zone.
  *
  * [PostgresXactStartSafeBoundary] is the implementation to use on Postgres.
  */
 fun interface SafeBoundary {
-    fun safeBefore(): LocalDateTime
+    fun read(): SafeBoundaryReading
 
     /**
      * What is currently holding the boundary back, for a log line or an error report. Called only when something has
@@ -48,9 +48,23 @@ fun interface SafeBoundary {
          * [BatchedAsyncEntityProcessor] using it wants a `stallThreshold` comfortably longer than [delay].
          */
         fun unsafeFixedDelay(delay: Duration, clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) }) =
-            SafeBoundary { clock().minus(delay) }
+            SafeBoundary { clock().let { SafeBoundaryReading(safeBefore = it.minus(delay), readAt = it) } }
     }
 }
+
+/**
+ * One reading of a [SafeBoundary].
+ *
+ * [readAt] is the moment the reading was taken, from the same clock that produced [safeBefore] — for
+ * [PostgresXactStartSafeBoundary] both come out of one query, so it costs nothing to report. It exists so that
+ * `readAt - safeBefore` gives how long the boundary has been held back without anybody consulting an application clock,
+ * which [BatchedAsyncEntityProcessor] uses to decide whether a stall is even possible before paying for the query that
+ * would confirm one.
+ *
+ * An implementation must not report a [readAt] earlier than its [safeBefore]; a boundary is a point in the past, never
+ * the future.
+ */
+data class SafeBoundaryReading(val safeBefore: LocalDateTime, val readAt: LocalDateTime)
 
 /**
  * Thrown rather than returning a boundary that would let the reader skip rows. [SafeBoundaryUnreliableException] and
@@ -156,7 +170,7 @@ class PostgresXactStartSafeBoundary(
         }
     }
 
-    override fun safeBefore(): LocalDateTime = observe().validated()
+    override fun read(): SafeBoundaryReading = observe().validated()
 
     private fun observe(): Observation {
         return transaction(db) {
@@ -170,6 +184,7 @@ class PostgresXactStartSafeBoundary(
                     boundary = rs.getObject(1, LocalDateTime::class.java),
                     redactedBackends = rs.getInt(2),
                     maxPreparedTransactions = rs.getInt(3),
+                    readAt = rs.getObject(4, LocalDateTime::class.java),
                 )
             }
         } ?: throw SafeBoundaryException("Reading the safe boundary produced no result")
@@ -180,8 +195,13 @@ class PostgresXactStartSafeBoundary(
      * without a database configured to provoke them: `max_prepared_transactions` in particular is a server-level
      * setting that cannot be changed per session.
      */
-    internal data class Observation(val boundary: LocalDateTime, val redactedBackends: Int, val maxPreparedTransactions: Int) {
-        fun validated(): LocalDateTime {
+    internal data class Observation(
+        val boundary: LocalDateTime,
+        val redactedBackends: Int,
+        val maxPreparedTransactions: Int,
+        val readAt: LocalDateTime = boundary,
+    ) {
+        fun validated(): SafeBoundaryReading {
             if (maxPreparedTransactions != 0) {
                 throw SafeBoundaryUnsupportedException(
                     "max_prepared_transactions is $maxPreparedTransactions, but a prepared transaction is not " +
@@ -199,13 +219,16 @@ class PostgresXactStartSafeBoundary(
                 )
             }
 
-            return boundary
+            return SafeBoundaryReading(boundary, readAt)
         }
     }
 
     private companion object {
         /**
-         * One round trip for the boundary, the redaction count and the prepared-transaction setting.
+         * One round trip for the boundary, the redaction count, the prepared-transaction setting and the moment the
+         * reading was taken. That last one is free here and is what lets a caller age the boundary without an
+         * application clock: `statement_timestamp()` is the cap the boundary is already computed against, so returning
+         * it as well costs nothing and is by construction at or after `safeBefore`.
          *
          * `pid <> pg_backend_pid()` excludes our own transaction, which is required rather than tidy: [safeBefore]
          * clears the snapshot first, so this is the *second* statement of its transaction and our own `xact_start`
@@ -238,7 +261,8 @@ class PostgresXactStartSafeBoundary(
                     statement_timestamp()
                 ) AT TIME ZONE 'UTC',
                 count(*) FILTER (WHERE backend_type IS NULL AND datname = current_database()),
-                current_setting('max_prepared_transactions')::int
+                current_setting('max_prepared_transactions')::int,
+                statement_timestamp() AT TIME ZONE 'UTC'
             FROM pg_stat_activity
         """.trimIndent()
 

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -44,8 +44,8 @@ fun interface SafeBoundary {
          * [clock] has to read the same wall-clock that stamps the polled column, so the default reads UTC. The JVM's
          * zone would offset the hold-back, cancelling it east of UTC and stalling reads for hours west of it.
          *
-         * Note that this boundary sits exactly [delay] behind now at all times, so a [BatchedAsyncEntityProcessor]
-         * using it needs a `stallThreshold` longer than [delay] — otherwise every poll reports a stall.
+         * The head of a table being written to sits up to [delay] above this boundary, so a
+         * [BatchedAsyncEntityProcessor] using it wants a `stallThreshold` comfortably longer than [delay].
          */
         fun unsafeFixedDelay(delay: Duration, clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) }) =
             SafeBoundary { clock().minus(delay) }

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -4,7 +4,6 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.time.Duration
 import java.time.LocalDateTime
-import java.time.ZoneOffset
 
 /**
  * Supplies the timestamp below which an [EntitySource]'s rows are safe to read, i.e. the point past which a
@@ -14,6 +13,12 @@ import java.time.ZoneOffset
  * transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes its rows visible half an hour
  * after the timestamp they carry. A reader whose bookmark has meanwhile passed 12:00 — which ordinary concurrent
  * traffic will do for it — never sees those rows again, with no error and nothing to alert on.
+ *
+ * Holding reads back by a fixed delay instead — the JDBC source connector's
+ * [`timestamp.delay.interval.ms`](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/source_config_options.html#mode)
+ * — is the tempting alternative, and is only ever probabilistically right: it holds while every transaction that writes
+ * the table commits inside the delay, which nothing enforces. Set it below your worst case and rows are dropped
+ * silently. That is the trade [PostgresXactStartSafeBoundary] exists to remove rather than to tune.
  *
  * The boundary is **exclusive**: only rows with `updated_at < safeBefore` may be read. It is compared directly against
  * the polled column, so it is a UTC [LocalDateTime] like an [EntityPosition], and an implementation reading it from a
@@ -32,24 +37,6 @@ fun interface SafeBoundary {
      */
     fun describeBlockers(): String = "no blocker diagnosis available from this SafeBoundary"
 
-    companion object {
-        /**
-         * A boundary of "now minus a fixed delay", equivalent to the JDBC source connector's
-         * [`timestamp.delay.interval.ms`](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/source_config_options.html#mode).
-         *
-         * **Not safe against long-running transactions**, hence the name: it holds only while every transaction that
-         * writes the table commits within [delay], and nothing enforces that — set it too low and rows are dropped
-         * silently. Use it for tests, or for a database with no `pg_stat_activity` equivalent.
-         *
-         * [clock] has to read the same wall-clock that stamps the polled column, so the default reads UTC. The JVM's
-         * zone would offset the hold-back, cancelling it east of UTC and stalling reads for hours west of it.
-         *
-         * The head of a table being written to sits up to [delay] above this boundary, so a
-         * [BatchedAsyncEntityProcessor] using it wants a `stallThreshold` comfortably longer than [delay].
-         */
-        fun unsafeFixedDelay(delay: Duration, clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) }) =
-            SafeBoundary { clock().let { SafeBoundaryReading(safeBefore = it.minus(delay), readAt = it) } }
-    }
 }
 
 /**

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -1,0 +1,248 @@
+package com.cultureamp.eventsourcing
+
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * Supplies the timestamp below which an [EntitySource]'s rows are safe to read, i.e. the point past which a
+ * [BatchedAsyncEntityProcessor] must not advance its bookmark.
+ *
+ * It is needed because an `updated_at` column does not record commit order. Postgres `now()` is fixed when a
+ * transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes its rows visible half an hour
+ * after the timestamp they carry. A reader whose bookmark has meanwhile passed 12:00 — which ordinary concurrent
+ * traffic will do for it — never sees those rows again, with no error and nothing to alert on.
+ *
+ * The boundary is **exclusive**: only rows with `updated_at < safeBefore()` may be read. It is compared directly
+ * against the polled column, so it is a UTC [LocalDateTime] like an [EntityPosition], and an implementation reading it
+ * from a database must convert explicitly rather than relying on the session time-zone.
+ *
+ * [PostgresXactStartSafeBoundary] is the implementation to use on Postgres.
+ */
+fun interface SafeBoundary {
+    fun safeBefore(): LocalDateTime
+
+    /**
+     * What is currently holding the boundary back, for a log line or an error report. Called only when something has
+     * already gone wrong, so it may run an extra query. A string rather than structured data because the only consumer
+     * is a human reading it, so an implementation can report whatever its database offers without every caller having
+     * to model it.
+     */
+    fun describeBlockers(): String = "no blocker diagnosis available from this SafeBoundary"
+
+    companion object {
+        /**
+         * A boundary of "now minus a fixed delay", equivalent to the JDBC source connector's
+         * [`timestamp.delay.interval.ms`](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/source_config_options.html#mode).
+         *
+         * **Not safe against long-running transactions**, hence the name: it holds only while every transaction that
+         * writes the table commits within [delay], and nothing enforces that — set it too low and rows are dropped
+         * silently. Use it for tests, or for a database with no `pg_stat_activity` equivalent.
+         *
+         * [clock] has to read the same wall-clock that stamps the polled column, so the default reads UTC. The JVM's
+         * zone would offset the hold-back, cancelling it east of UTC and stalling reads for hours west of it.
+         */
+        fun unsafeFixedDelay(delay: Duration, clock: () -> LocalDateTime = { LocalDateTime.now(ZoneOffset.UTC) }) =
+            SafeBoundary { clock().minus(delay) }
+    }
+}
+
+/**
+ * Thrown rather than returning a boundary that would let the reader skip rows. [SafeBoundaryUnreliableException] and
+ * [SafeBoundaryUnsupportedException] are both configuration problems, so a processor hitting one keeps hitting it: the
+ * intent is to wedge it loudly rather than let it run unsafely.
+ */
+open class SafeBoundaryException(message: String) : RuntimeException(message)
+
+/** Thrown when `pg_stat_activity` is hiding backends from the reader, leaving `min(xact_start)` incomplete. */
+class SafeBoundaryUnreliableException(message: String) : SafeBoundaryException(message)
+
+/** Thrown when the database is configured in a way the boundary cannot reason about. */
+class SafeBoundaryUnsupportedException(message: String) : SafeBoundaryException(message)
+
+/**
+ * Thrown when the boundary has held a processor back for longer than its stall threshold: there are rows it is
+ * forbidden to read, and that has been true for too long. Nothing is lost and it recovers once the blocking transaction
+ * ends, so this is a staleness alarm — thrown rather than logged because "publishing stopped hours ago" is the class of
+ * problem the boundary exists to remove, and a graph is not where that should be noticed. The message carries
+ * [SafeBoundary.describeBlockers].
+ */
+class SafeBoundaryStalledException(message: String) : SafeBoundaryException(message)
+
+/**
+ * Closes the commit race using `pg_stat_activity.xact_start`, which is the same clock reading `now()` stamps into
+ * `updated_at`: never advance the reader past the start time of the oldest transaction that could still commit. It errs
+ * one way only, withholding rows that were in fact safe to read — they arrive on a later poll — and never admitting a
+ * row that has not yet appeared.
+ *
+ * ## The boundary must be read before the snapshot the rows are read with
+ *
+ * `pg_stat_activity` is not MVCC; it reads shared memory at execution time. So the moment it is evaluated, `B`, is
+ * independent of the snapshot `S` the table is read with, and a transaction committing in `(S, B]` is invisible at `S`
+ * and already gone from `pg_stat_activity` at `B` — neither visible nor excluded, therefore missed. Safety needs
+ * `B <= S`.
+ *
+ * [BatchedAsyncEntityProcessor] gets that by calling [safeBefore] in its own transaction, which commits before the
+ * source's read transaction starts, so `B < S` holds whatever the isolation level. **Do not merge the two to save a
+ * round trip.** Every merged arrangement is either unsafe or accidentally safe: one statement (CTE, join or subquery)
+ * evaluates `B` during execution and so after `S`; two statements in one `REPEATABLE READ` transaction pin `S` at the
+ * first, leaving the boundary fresher than the data; `READ COMMITTED`, or a `VOLATILE` plpgsql function wrapping both,
+ * is safe only by virtue of an isolation level set in connection-pool configuration by someone with no reason to know
+ * this reader depends on it.
+ *
+ * ## Redaction is the failure that most needs detecting
+ *
+ * `pg_stat_activity` nulls columns for backends belonging to roles the reader is not a member of. `min(xact_start)`
+ * then collapses to the reader's own transactions and the boundary degrades to "now" — failing open, into exactly the
+ * bug it exists to close. Every call therefore counts hidden backends and throws [SafeBoundaryUnreliableException]
+ * rather than reporting a boundary it cannot trust. Grant `pg_read_all_stats` to the reading role.
+ * `max_prepared_transactions` is asserted to be 0 for the same reason: a prepared transaction is not an ordinary
+ * backend, so it would be invisible here.
+ *
+ * ## Liveness
+ *
+ * The boundary cannot know which transactions will write the table it guards, so it is not filtered by table: **any**
+ * long-running transaction in the same database holds the reader up — a reporting query, a leaked `idle in transaction`
+ * connection, a long `CREATE INDEX`. That is the intended trade, silent data loss for a visible stall, which
+ * [AsyncEntityProcessorMonitor]'s `latencyMs` reports and [SafeBoundaryStalledException] escalates. Setting
+ * `idle_in_transaction_session_timeout` bounds the worst case; routing long reporting queries to a replica keeps them
+ * out of the primary's `pg_stat_activity` entirely.
+ *
+ * @param db the database to read the boundary from. Must be the one the [EntitySource] reads, since `xact_start` values
+ * are only comparable within one instance.
+ */
+class PostgresXactStartSafeBoundary(
+    private val db: Database,
+    private val knownApplicationNames: Set<String> = emptySet(),
+) : SafeBoundary {
+
+    /**
+     * Names the oldest open transactions, so a [SafeBoundaryStalledException] says which session to go and close.
+     *
+     * Each is tagged `[known]` or `[UNRECOGNISED]` against [knownApplicationNames], which is the practical way to tell
+     * one of your own services from somebody's psql session. `application_name` is self-reported, which is exactly why
+     * it stays a diagnostic and never reaches the boundary predicate: excluding a session because of its name would
+     * break safety in the case that most deserves care, somebody hand-editing rows in production.
+     *
+     * `pg_stat_activity.query` is deliberately not reported. For a session idle in transaction that is the last
+     * statement it ran, which on a write path carries row values — customer data, en route to an error tracker.
+     */
+    override fun describeBlockers(): String {
+        val blockers = transaction(db) {
+            exec(BLOCKERS_SQL) { rs ->
+                buildList {
+                    while (rs.next()) {
+                        val applicationName = rs.getString("application_name").orEmpty()
+                        val tag = if (applicationName in knownApplicationNames) "known" else "UNRECOGNISED"
+                        add(
+                            "pid=${rs.getInt("pid")} application_name='$applicationName' [$tag] " +
+                                "state='${rs.getString("state").orEmpty()}' " +
+                                "openFor=${Duration.ofMillis((rs.getDouble("open_for_seconds") * 1000).toLong())}",
+                        )
+                    }
+                }
+            }
+        }.orEmpty()
+
+        return if (blockers.isEmpty()) {
+            "no open transactions found, so the boundary is not being held back by one now"
+        } else {
+            "oldest open transactions: ${blockers.joinToString("; ")}"
+        }
+    }
+
+    override fun safeBefore(): LocalDateTime {
+        val observation = transaction(db) {
+            // A pg_stat_activity read is cached for the whole transaction — pgstat_read_current_status() returns early
+            // once the snapshot is populated, and it is discarded only at transaction end. Clearing it first means
+            // BOUNDARY_SQL's own read populates it, which is what the statement_timestamp() cap below relies on.
+            exec("SELECT pg_stat_clear_snapshot()")
+            exec(BOUNDARY_SQL) { rs ->
+                if (!rs.next()) throw SafeBoundaryException("Reading the safe boundary returned no row, which pg_stat_activity cannot do")
+                Observation(
+                    boundary = rs.getObject(1, LocalDateTime::class.java),
+                    redactedBackends = rs.getInt(2),
+                    maxPreparedTransactions = rs.getInt(3),
+                )
+            }
+        } ?: throw SafeBoundaryException("Reading the safe boundary produced no result")
+
+        if (observation.maxPreparedTransactions != 0) {
+            throw SafeBoundaryUnsupportedException(
+                "max_prepared_transactions is ${observation.maxPreparedTransactions}, but a prepared transaction is not " +
+                    "an ordinary backend in pg_stat_activity and so cannot be seen by this boundary. Set it to 0, or " +
+                    "position rows by commit order instead.",
+            )
+        }
+
+        if (observation.redactedBackends != 0) {
+            throw SafeBoundaryUnreliableException(
+                "${observation.redactedBackends} backend(s) attached to this database are hidden from this connection " +
+                    "in pg_stat_activity, so min(xact_start) is incomplete and rows committed by those backends could " +
+                    "be skipped silently. Grant pg_read_all_stats to this role, or run every writer under a role this " +
+                    "one is a member of.",
+            )
+        }
+
+        return observation.boundary
+    }
+
+    private data class Observation(val boundary: LocalDateTime, val redactedBackends: Int, val maxPreparedTransactions: Int)
+
+    private companion object {
+        /**
+         * One round trip for the boundary, the redaction count and the prepared-transaction setting.
+         *
+         * `pid <> pg_backend_pid()` excludes our own transaction, which is required rather than tidy: [safeBefore]
+         * clears the snapshot first, so this is the *second* statement of its transaction and our own `xact_start`
+         * precedes this `statement_timestamp()` — half a millisecond, measured on Postgres 14. Counting ourselves would
+         * pin the boundary to the reader's own poll, and an otherwise idle database would never advance.
+         *
+         * `statement_timestamp()` is a cap, not a fallback. A transaction this statement's snapshot could have missed
+         * published its `xact_start` after the snapshot was taken, and Postgres publishes that inside
+         * `StartTransaction()` before any statement of the transaction runs, so every row it writes is stamped above
+         * the cap. (Unless the system clock steps backwards mid-transaction,
+         * which is why the README recommends stamping `GREATEST(clock_timestamp(), transaction_timestamp())`.) `LEAST`
+         * ignores nulls, so the cap doubles as the "nothing else is open" case, and no application clock is involved.
+         *
+         * `AT TIME ZONE 'UTC'` renders the boundary as the naive UTC timestamp the polled column holds. Spelled out
+         * rather than left to the session's `TimeZone`, which is connection-pool configuration this reader does not
+         * control.
+         *
+         * The redaction count keys on `backend_type IS NULL`, since a visible row always has one and a redacted row
+         * never does; `state IS NULL` would false-positive on background workers. Scoping it to this database is exact
+         * rather than convenient: redaction leaves `datname` intact, a backend has to be attached to this database to
+         * write the guarded table, and one already holding a transaction open has a `datname` by definition. What the
+         * scope drops is auxiliary processes — checkpointer, walwriter, autovacuum launcher — which report no database
+         * and run no transaction over a user table. They are redacted from anyone without `pg_read_all_stats`, so
+         * counting them would leave this check permanently unsatisfiable.
+         */
+        val BOUNDARY_SQL = """
+            SELECT
+                LEAST(
+                    min(xact_start) FILTER (WHERE datname = current_database() AND pid <> pg_backend_pid()),
+                    statement_timestamp()
+                ) AT TIME ZONE 'UTC',
+                count(*) FILTER (WHERE backend_type IS NULL AND datname = current_database()),
+                current_setting('max_prepared_transactions')::int
+            FROM pg_stat_activity
+        """.trimIndent()
+
+        /** The same population the boundary is computed from, oldest first. `query` is not selected: see [describeBlockers]. */
+        val BLOCKERS_SQL = """
+            SELECT
+                pid,
+                application_name,
+                state,
+                extract(epoch FROM (clock_timestamp() - xact_start)) AS open_for_seconds
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND xact_start IS NOT NULL
+              AND pid <> pg_backend_pid()
+            ORDER BY xact_start ASC
+            LIMIT 5
+        """.trimIndent()
+    }
+}

--- a/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
+++ b/src/main/kotlin/com/cultureamp/eventsourcing/SafeBoundary.kt
@@ -14,12 +14,6 @@ import java.time.LocalDateTime
  * after the timestamp they carry. A reader whose bookmark has meanwhile passed 12:00 — which ordinary concurrent
  * traffic will do for it — never sees those rows again, with no error and nothing to alert on.
  *
- * Holding reads back by a fixed delay instead — the JDBC source connector's
- * [`timestamp.delay.interval.ms`](https://docs.confluent.io/kafka-connectors/jdbc/current/source-connector/source_config_options.html#mode)
- * — is the tempting alternative, and is only ever probabilistically right: it holds while every transaction that writes
- * the table commits inside the delay, which nothing enforces. Set it below your worst case and rows are dropped
- * silently. That is the trade [PostgresXactStartSafeBoundary] exists to remove rather than to tune.
- *
  * The boundary is **exclusive**: only rows with `updated_at < safeBefore` may be read. It is compared directly against
  * the polled column, so it is a UTC [LocalDateTime] like an [EntityPosition], and an implementation reading it from a
  * database must convert explicitly rather than relying on the session time-zone.

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
@@ -25,7 +25,7 @@ class AsyncEntityProcessorMonitorTest : DescribeSpec({
             bookmarkStore = bookmarkStore,
             bookmarkName = "goal-relationships",
             entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
-            safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+            safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)).let { SafeBoundaryReading(it, it) } },
             batchSize = batchSize,
             startLog = {},
             endLog = { _, _ -> },
@@ -95,7 +95,7 @@ class AsyncEntityProcessorMonitorTest : DescribeSpec({
                     bookmarkStore = InMemoryEntityBookmarkStore(),
                     bookmarkName = name,
                     entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
-                    safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                    safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)).let { SafeBoundaryReading(it, it) } },
                     startLog = {},
                     endLog = { _, _ -> },
                 )

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
@@ -27,7 +27,6 @@ class AsyncEntityProcessorMonitorTest : DescribeSpec({
             entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
             safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
             batchSize = batchSize,
-            clock = { baseTime },
             startLog = {},
             endLog = { _, _ -> },
         )

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
@@ -27,6 +27,7 @@ class AsyncEntityProcessorMonitorTest : DescribeSpec({
             entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
             safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
             batchSize = batchSize,
+            clock = { baseTime },
             startLog = {},
             endLog = { _, _ -> },
         )

--- a/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/AsyncEntityProcessorMonitorTest.kt
@@ -1,0 +1,110 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+class AsyncEntityProcessorMonitorTest : DescribeSpec({
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+    val accountId = UUID.randomUUID()
+
+    fun goalRelationship(secondsAfterBase: Int) =
+        GoalRelationship(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), accountId, createdAt = fixtureCreatedAt, updatedAt = baseTime.plusSeconds(secondsAfterBase.toLong()))
+
+    fun monitoredProcessor(
+        goalRelationships: List<GoalRelationship>,
+        bookmarkStore: EntityBookmarkStore,
+        batchSize: Int = 1000,
+    ): BatchedAsyncEntityProcessor<GoalRelationship> {
+        val source = InMemoryEntitySource(goalRelationships.map { PositionedEntity(it, it.position) })
+        return BatchedAsyncEntityProcessor(
+            entitySource = source,
+            entityUpdatedAtStats = source,
+            bookmarkStore = bookmarkStore,
+            bookmarkName = "goal-relationships",
+            entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+            safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+            batchSize = batchSize,
+            startLog = {},
+            endLog = { _, _ -> },
+        )
+    }
+
+    describe("run") {
+        it("reports that nothing has been processed yet") {
+            val goalRelationships = listOf(goalRelationship(1), goalRelationship(61))
+            val processor = monitoredProcessor(goalRelationships, InMemoryEntityBookmarkStore())
+            var lag: EntityLag? = null
+            val monitor = AsyncEntityProcessorMonitor(listOf(processor), { lag = it }, clock = { baseTime.plusSeconds(120) })
+
+            monitor.run()
+
+            lag!!.name shouldBe "goal-relationships"
+            lag!!.hasStarted shouldBe false
+            lag!!.lastUpdatedAt shouldBe baseTime.plusSeconds(61)
+            lag!!.lagMs shouldBe null
+            lag!!.latencyMs shouldBe null
+        }
+
+        it("reports how far behind the head of the table a partially caught-up processor is") {
+            val goalRelationships = listOf(goalRelationship(1), goalRelationship(61))
+            val processor = monitoredProcessor(goalRelationships, InMemoryEntityBookmarkStore(), batchSize = 1)
+            var lag: EntityLag? = null
+            val monitor = AsyncEntityProcessorMonitor(listOf(processor), { lag = it }, clock = { baseTime.plusSeconds(120) })
+
+            processor.processOneBatch()
+            monitor.run()
+
+            lag!!.hasStarted shouldBe true
+            lag!!.bookmarkUpdatedAt shouldBe baseTime.plusSeconds(1)
+            lag!!.lagMs shouldBe 60_000
+            lag!!.latencyMs shouldBe 119_000
+        }
+
+        it("reports zero lag once caught up") {
+            val goalRelationships = listOf(goalRelationship(1), goalRelationship(61))
+            val processor = monitoredProcessor(goalRelationships, InMemoryEntityBookmarkStore())
+            var lag: EntityLag? = null
+            val monitor = AsyncEntityProcessorMonitor(listOf(processor), { lag = it }, clock = { baseTime.plusSeconds(120) })
+
+            processor.processOneBatch()
+            monitor.run()
+
+            lag!!.lagMs shouldBe 0
+            lag!!.latencyMs shouldBe 59_000
+        }
+
+        it("reports null lag for an empty table") {
+            val processor = monitoredProcessor(emptyList(), InMemoryEntityBookmarkStore())
+            var lag: EntityLag? = null
+            val monitor = AsyncEntityProcessorMonitor(listOf(processor), { lag = it }, clock = { baseTime })
+
+            monitor.run()
+
+            lag!!.lastUpdatedAt shouldBe null
+            lag!!.lagMs shouldBe null
+        }
+
+        it("reports on every processor it is given") {
+            val processors = listOf("a", "b").map { name ->
+                BatchedAsyncEntityProcessor(
+                    entitySource = InMemoryEntitySource(emptyList<PositionedEntity<GoalRelationship>>()),
+                    entityUpdatedAtStats = EntityUpdatedAtStats.from { baseTime },
+                    bookmarkStore = InMemoryEntityBookmarkStore(),
+                    bookmarkName = name,
+                    entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                    safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                    startLog = {},
+                    endLog = { _, _ -> },
+                )
+            }
+            val lags = mutableListOf<EntityLag>()
+
+            AsyncEntityProcessorMonitor(processors, { lags += it }).run()
+
+            lags.map { it.name } shouldBe listOf("a", "b")
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
@@ -78,7 +78,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 batchSize = 2,
-                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)).let { SafeBoundaryReading(it, it) } },
             )
             val first = insertGoalRelationship(baseTime.plusSeconds(1))
             val second = insertGoalRelationship(baseTime.plusSeconds(2))
@@ -111,7 +111,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkStore = bookmarkStore,
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
-                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)).let { SafeBoundaryReading(it, it) } },
             )
             // 123.456ms past the second: representable in a Postgres `timestamp`, but truncated to 123ms by a
             // millisecond-precision type, which would leave the bookmark behind the row and re-select it forever
@@ -155,7 +155,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { _: UUID -> },
                 batchSize = 1,
-                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)).let { SafeBoundaryReading(it, it) } },
             )
             insertGoalRelationship(baseTime.plusSeconds(1))
             insertGoalRelationship(baseTime.plusSeconds(11))

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
@@ -79,7 +79,6 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 batchSize = 2,
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
-                clock = { baseTime },
             )
             val first = insertGoalRelationship(baseTime.plusSeconds(1))
             val second = insertGoalRelationship(baseTime.plusSeconds(2))
@@ -113,7 +112,6 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
-                clock = { baseTime },
             )
             // 123.456ms past the second: representable in a Postgres `timestamp`, but truncated to 123ms by a
             // millisecond-precision type, which would leave the bookmark behind the row and re-select it forever
@@ -137,7 +135,6 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(5)) { now },
-                clock = { now },
             )
             val settled = insertGoalRelationship(baseTime.plusSeconds(1))
             val inFlight = insertGoalRelationship(baseTime.plusSeconds(9))
@@ -159,7 +156,6 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 entityProcessor = EntityProcessor.from { _: UUID -> },
                 batchSize = 1,
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
-                clock = { baseTime },
             )
             insertGoalRelationship(baseTime.plusSeconds(1))
             insertGoalRelationship(baseTime.plusSeconds(11))

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
@@ -79,6 +79,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 batchSize = 2,
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                clock = { baseTime },
             )
             val first = insertGoalRelationship(baseTime.plusSeconds(1))
             val second = insertGoalRelationship(baseTime.plusSeconds(2))
@@ -112,6 +113,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                clock = { baseTime },
             )
             // 123.456ms past the second: representable in a Postgres `timestamp`, but truncated to 123ms by a
             // millisecond-precision type, which would leave the bookmark behind the row and re-select it forever
@@ -135,6 +137,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
                 safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(5)) { now },
+                clock = { now },
             )
             val settled = insertGoalRelationship(baseTime.plusSeconds(1))
             val inFlight = insertGoalRelationship(baseTime.plusSeconds(9))
@@ -156,6 +159,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 entityProcessor = EntityProcessor.from { _: UUID -> },
                 batchSize = 1,
                 safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+                clock = { baseTime },
             )
             insertGoalRelationship(baseTime.plusSeconds(1))
             insertGoalRelationship(baseTime.plusSeconds(11))

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
@@ -134,7 +134,7 @@ class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
                 bookmarkStore = bookmarkStore,
                 bookmarkName = bookmarkName,
                 entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
-                safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(5)) { now },
+                safeBoundary = SafeBoundary { SafeBoundaryReading(safeBefore = now.minusSeconds(5), readAt = now) },
             )
             val settled = insertGoalRelationship(baseTime.plusSeconds(1))
             val inFlight = insertGoalRelationship(baseTime.plusSeconds(9))

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorIntegrationTest.kt
@@ -1,0 +1,179 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.common.Action
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.jetbrains.exposed.v1.jdbc.update
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+class BatchedAsyncEntityProcessorIntegrationTest : DescribeSpec({
+    val db = PgTestConfig.db ?: Database.connect(url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    val goalRelationships = GoalRelationshipsTable()
+    val bookmarksTable = EntityBookmarks("entity_bookmarks_integration")
+    val bookmarkStore = RelationalDatabaseEntityBookmarkStore(db, bookmarksTable)
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+    val accountId = UUID.randomUUID()
+    val bookmarkName = "GoalRelationshipProjector"
+
+    val entitySource = RelationalDatabaseEntitySource(
+        db = db,
+        table = goalRelationships,
+        updatedAtColumn = goalRelationships.updatedAt,
+        idColumn = goalRelationships.id,
+        rowToEntity = { it[goalRelationships.id] },
+    )
+
+    fun insertGoalRelationship(updatedAt: LocalDateTime): GoalRelationship {
+        val relationship = GoalRelationship(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), accountId, baseTime, updatedAt)
+        transaction(db) {
+            goalRelationships.insert {
+                it[goalRelationships.id] = relationship.id
+                it[goalRelationships.childGoalId] = relationship.childGoalId
+                it[goalRelationships.parentGoalId] = relationship.parentGoalId
+                it[goalRelationships.accountId] = relationship.accountId
+                it[goalRelationships.createdAt] = relationship.createdAt
+                it[goalRelationships.updatedAt] = relationship.updatedAt
+                it[goalRelationships.cascadingWeight] = relationship.cascadingWeight
+            }
+        }
+        return relationship
+    }
+
+    fun touchGoalRelationship(relationship: GoalRelationship, updatedAt: LocalDateTime) {
+        transaction(db) {
+            goalRelationships.update({ goalRelationships.id eq relationship.id }) {
+                it[goalRelationships.updatedAt] = updatedAt
+            }
+        }
+    }
+
+    beforeTest {
+        transaction(db) {
+            SchemaUtils.create(goalRelationships)
+            SchemaUtils.create(bookmarksTable)
+        }
+    }
+
+    afterTest {
+        transaction(db) {
+            SchemaUtils.drop(bookmarksTable)
+            SchemaUtils.drop(goalRelationships)
+        }
+    }
+
+    describe("BatchedAsyncEntityProcessor against a real table") {
+        it("processes a table, persists its position, and resumes from it") {
+            val processed = mutableListOf<UUID>()
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = entitySource,
+                entityUpdatedAtStats = entitySource,
+                bookmarkStore = bookmarkStore,
+                bookmarkName = bookmarkName,
+                entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
+                batchSize = 2,
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+            )
+            val first = insertGoalRelationship(baseTime.plusSeconds(1))
+            val second = insertGoalRelationship(baseTime.plusSeconds(2))
+            val third = insertGoalRelationship(baseTime.plusSeconds(3))
+
+            bookmarkStore.bookmarkFor(bookmarkName) shouldBe EntityBookmark(bookmarkName, null)
+
+            processor.processOneBatch() shouldBe Action.Continue
+            processed shouldBe listOf(first.id, second.id)
+            bookmarkStore.bookmarkFor(bookmarkName).position shouldBe second.position
+
+            processor.processOneBatch() shouldBe Action.Wait
+            processed shouldBe listOf(first.id, second.id, third.id)
+
+            // nothing new to do, and crucially the persisted position round-trips well enough not to re-read the last row
+            processor.processOneBatch() shouldBe Action.Wait
+            processed shouldBe listOf(first.id, second.id, third.id)
+
+            // a row that gets touched is picked up again
+            touchGoalRelationship(first, baseTime.plusSeconds(4))
+            processor.processOneBatch() shouldBe Action.Wait
+            processed shouldBe listOf(first.id, second.id, third.id, first.id)
+        }
+
+        it("round-trips a sub-millisecond updated-at exactly, so the bookmarked row is not re-read") {
+            val processed = mutableListOf<UUID>()
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = entitySource,
+                entityUpdatedAtStats = entitySource,
+                bookmarkStore = bookmarkStore,
+                bookmarkName = bookmarkName,
+                entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+            )
+            // 123.456ms past the second: representable in a Postgres `timestamp`, but truncated to 123ms by a
+            // millisecond-precision type, which would leave the bookmark behind the row and re-select it forever
+            val subMillisecond = insertGoalRelationship(baseTime.plusSeconds(1).plusNanos(123_456_000))
+
+            processor.processOneBatch()
+            processed shouldBe listOf(subMillisecond.id)
+            bookmarkStore.bookmarkFor(bookmarkName).position shouldBe subMillisecond.position
+
+            processor.processOneBatch() shouldBe Action.Wait
+            processed shouldBe listOf(subMillisecond.id)
+        }
+
+        it("does not read rows at or beyond the safe boundary") {
+            val processed = mutableListOf<UUID>()
+            var now = baseTime.plusSeconds(10)
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = entitySource,
+                entityUpdatedAtStats = entitySource,
+                bookmarkStore = bookmarkStore,
+                bookmarkName = bookmarkName,
+                entityProcessor = EntityProcessor.from { id: UUID -> processed += id },
+                safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(5)) { now },
+            )
+            val settled = insertGoalRelationship(baseTime.plusSeconds(1))
+            val inFlight = insertGoalRelationship(baseTime.plusSeconds(9))
+
+            processor.processOneBatch()
+            processed shouldBe listOf(settled.id)
+
+            now = baseTime.plusSeconds(20)
+            processor.processOneBatch()
+            processed shouldBe listOf(settled.id, inFlight.id)
+        }
+
+        it("reports lag against the head of the table") {
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = entitySource,
+                entityUpdatedAtStats = entitySource,
+                bookmarkStore = bookmarkStore,
+                bookmarkName = bookmarkName,
+                entityProcessor = EntityProcessor.from { _: UUID -> },
+                batchSize = 1,
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(1)) },
+            )
+            insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(11))
+            var lag: EntityLag? = null
+            val monitor = AsyncEntityProcessorMonitor(listOf(processor), { lag = it }, clock = { baseTime.plusSeconds(31) })
+
+            monitor.run()
+            lag!!.hasStarted shouldBe false
+
+            processor.processOneBatch()
+            monitor.run()
+            lag!!.lagMs shouldBe 10_000
+            lag!!.latencyMs shouldBe 30_000
+
+            processor.processOneBatch()
+            monitor.run()
+            lag!!.lagMs shouldBe 0
+            lag!!.latencyMs shouldBe 20_000
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
@@ -11,7 +11,15 @@ import java.util.UUID
 
 class BatchedAsyncEntityProcessorTest : DescribeSpec({
     val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
-    val wellAfterAnyRow = SafeBoundary { baseTime.plus(Duration.ofHours(1)) }
+    /**
+     * A boundary pinned at [safeBefore] and read at [readAt]. The gap between them is how long the boundary has been
+     * held back, which is what the processor pre-filters a stall check on, so a spec that wants a stall has to say the
+     * boundary was read well after it was pinned.
+     */
+    fun boundaryOf(safeBefore: LocalDateTime, readAt: LocalDateTime = safeBefore) =
+        SafeBoundary { SafeBoundaryReading(safeBefore, readAt) }
+
+    val wellAfterAnyRow = boundaryOf(baseTime.plus(Duration.ofHours(1)))
     val accountId = UUID.randomUUID()
 
     fun goalRelationship(secondsAfterBase: Int, id: UUID = UUID.randomUUID()) =
@@ -130,7 +138,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             val processor = stallableProcessorFor(
                 listOf(goalRelationship(secondsAfterBase = 2 * 60 * 60)),
                 safeBoundary = object : SafeBoundary {
-                    override fun safeBefore() = baseTime
+                    override fun read() = SafeBoundaryReading(safeBefore = baseTime, readAt = baseTime.plusSeconds(3 * 60 * 60))
                     override fun describeBlockers() = "pid=999 application_name='psql' [UNRECOGNISED]"
                 },
             )
@@ -142,10 +150,32 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             exception.message!! shouldContain "goal-relationships"
         }
 
+        it("does not query the head of the table while the boundary is too fresh for a stall to be possible") {
+            // the pre-filter: a row cannot be stamped after the boundary was read, so a boundary read moments after it
+            // was pinned cannot have a threshold's worth of writes above it, whatever the table contains
+            var headReads = 0
+            val waiting = goalRelationship(secondsAfterBase = 2 * 60 * 60)
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(listOf(positioned(waiting))),
+                entityUpdatedAtStats = EntityUpdatedAtStats.from { headReads++; waiting.updatedAt },
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                safeBoundary = boundaryOf(baseTime, readAt = baseTime.plusSeconds(1)),
+                stallThreshold = Duration.ofHours(1),
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            processor.processOneBatch() shouldBe Action.Wait
+
+            headReads shouldBe 0
+        }
+
         it("says nothing while the rows it cannot read span less than the stall threshold") {
             val processor = stallableProcessorFor(
                 listOf(goalRelationship(secondsAfterBase = 59 * 60)),
-                safeBoundary = SafeBoundary { baseTime },
+                safeBoundary = boundaryOf(baseTime, readAt = baseTime.plusSeconds(3 * 60 * 60)),
             )
 
             processor.processOneBatch() shouldBe Action.Wait
@@ -158,7 +188,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             bookmarkStore.save("goal-relationships", done.position)
             val processor = stallableProcessorFor(
                 listOf(done),
-                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(5)) },
+                safeBoundary = boundaryOf(baseTime.plus(Duration.ofHours(5)), readAt = baseTime.plus(Duration.ofHours(11))),
                 bookmarkStore = bookmarkStore,
             )
 
@@ -172,7 +202,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             val blocked = goalRelationship(secondsAfterBase = 3 * 60 * 60)
             val processor = stallableProcessorFor(
                 readable + blocked,
-                safeBoundary = SafeBoundary { baseTime.plusSeconds(4) },
+                safeBoundary = boundaryOf(baseTime.plusSeconds(4), readAt = baseTime.plus(Duration.ofHours(4))),
                 batchSize = 1,
             )
 
@@ -189,7 +219,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             var boundary = baseTime
             val processor = stallableProcessorFor(
                 listOf(waiting),
-                safeBoundary = SafeBoundary { boundary },
+                safeBoundary = SafeBoundary { SafeBoundaryReading(boundary, boundary.plusSeconds(3 * 60 * 60)) },
                 stallBehaviour = StallBehaviour.LogAndContinue { logged += it },
                 processed = processed,
             )
@@ -213,7 +243,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 listOf(onTheBoundary),
                 processed,
                 bookmarkStore,
-                safeBoundary = SafeBoundary { onTheBoundary.updatedAt },
+                safeBoundary = boundaryOf(onTheBoundary.updatedAt),
             )
 
             processor.processOneBatch()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
@@ -1,0 +1,332 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.common.Action
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+class BatchedAsyncEntityProcessorTest : DescribeSpec({
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+    val wellAfterAnyRow = SafeBoundary { baseTime.plus(Duration.ofHours(1)) }
+    val accountId = UUID.randomUUID()
+
+    fun goalRelationship(secondsAfterBase: Int, id: UUID = UUID.randomUUID()) =
+        GoalRelationship(id, UUID.randomUUID(), UUID.randomUUID(), accountId, createdAt = fixtureCreatedAt, updatedAt = baseTime.plusSeconds(secondsAfterBase.toLong()))
+
+    fun positioned(goalRelationship: GoalRelationship) = PositionedEntity(goalRelationship, goalRelationship.position)
+
+    fun processorFor(
+        goalRelationships: List<GoalRelationship>,
+        processed: MutableList<GoalRelationship>,
+        bookmarkStore: EntityBookmarkStore,
+        batchSize: Int = 1000,
+        safeBoundary: SafeBoundary = wellAfterAnyRow,
+    ) = BatchedAsyncEntityProcessor(
+        entitySource = InMemoryEntitySource(goalRelationships.map(::positioned)),
+        entityUpdatedAtStats = InMemoryEntitySource(goalRelationships.map(::positioned)),
+        bookmarkStore = bookmarkStore,
+        bookmarkName = "goal-relationships",
+        entityProcessor = EntityProcessor.from { goalRelationship: GoalRelationship -> processed += goalRelationship },
+        safeBoundary = safeBoundary,
+        batchSize = batchSize,
+        startLog = {},
+        endLog = { _, _ -> },
+    )
+
+    describe("processOneBatch") {
+        it("processes rows in updated-at order and bookmarks each one") {
+            val first = goalRelationship(1)
+            val second = goalRelationship(2)
+            val third = goalRelationship(3)
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+
+            // deliberately out of order in the source, which is expected to sort them
+            val action = processorFor(listOf(third, first, second), processed, bookmarkStore).processOneBatch()
+
+            processed shouldBe listOf(first, second, third)
+            bookmarkStore.saved.map { it.position } shouldBe listOf(first.position, second.position, third.position)
+            bookmarkStore.bookmarkFor("goal-relationships") shouldBe EntityBookmark("goal-relationships", third.position)
+            action shouldBe Action.Wait
+        }
+
+        it("starts from an existing bookmark rather than the beginning") {
+            val first = goalRelationship(1)
+            val second = goalRelationship(2)
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            bookmarkStore.save("goal-relationships", first.position)
+
+            processorFor(listOf(first, second), processed, bookmarkStore).processOneBatch()
+
+            processed shouldBe listOf(second)
+        }
+
+        it("tiebreaks on id so that rows sharing an updated-at are each processed exactly once across batches") {
+            val sameSecond = (1..5).map { goalRelationship(1) }
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            val processor = processorFor(sameSecond, processed, bookmarkStore, batchSize = 2)
+
+            processor.processOneBatch() shouldBe Action.Continue
+            processor.processOneBatch() shouldBe Action.Continue
+            processor.processOneBatch() shouldBe Action.Wait
+            processor.processOneBatch() shouldBe Action.Wait
+
+            processed.toSet() shouldBe sameSecond.toSet()
+            processed.size shouldBe 5
+        }
+
+        it("does not read rows at or beyond the safe boundary, and picks them up once the boundary passes them") {
+            val old = goalRelationship(0)
+            val fresh = goalRelationship(10)
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            var now = fresh.updatedAt.plus(Duration.ofMillis(500))
+
+            val processor = processorFor(
+                listOf(old, fresh),
+                processed,
+                bookmarkStore,
+                safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofMillis(1000)) { now },
+            )
+
+            processor.processOneBatch()
+            processed shouldBe listOf(old)
+
+            now = fresh.updatedAt.plus(Duration.ofMillis(1500))
+            processor.processOneBatch()
+            processed shouldBe listOf(old, fresh)
+        }
+
+        it("throws once it has been held back by the boundary for longer than the stall threshold") {
+            val waiting = goalRelationship(10)
+            var now = baseTime
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(listOf(positioned(waiting))),
+                entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(waiting))),
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                // pinned well before the waiting row, as an open transaction would pin it
+                safeBoundary = object : SafeBoundary {
+                    override fun safeBefore() = baseTime
+                    override fun describeBlockers() = "pid=999 application_name='psql' [UNRECOGNISED]"
+                },
+                stallThreshold = Duration.ofHours(1),
+                clock = { now },
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            // held back, but not yet for long enough to complain about
+            processor.processOneBatch() shouldBe Action.Wait
+            now = baseTime.plus(Duration.ofMinutes(59))
+            processor.processOneBatch() shouldBe Action.Wait
+
+            now = baseTime.plus(Duration.ofMinutes(61))
+            val exception = shouldThrow<SafeBoundaryStalledException> { processor.processOneBatch() }
+
+            // the report has to name the session to go and close, or it just says "publishing is behind"
+            exception.message!! shouldContain "application_name='psql'"
+            exception.message!! shouldContain "goal-relationships"
+        }
+
+        it("does not throw when it has nothing to do, however old the boundary is") {
+            // an idle table is not a stall: everything in it is already behind the boundary
+            val done = goalRelationship(1)
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            bookmarkStore.save("goal-relationships", done.position)
+            var now = baseTime
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(listOf(positioned(done))),
+                entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(done))),
+                bookmarkStore = bookmarkStore,
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(5)) },
+                stallThreshold = Duration.ofHours(1),
+                clock = { now },
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            processor.processOneBatch()
+            now = baseTime.plus(Duration.ofDays(1))
+
+            processor.processOneBatch() shouldBe Action.Wait
+        }
+
+        it("does not throw while it is still making progress, however far behind the boundary is") {
+            // the backfill case: an old boundary while rows behind it are read happily is not a stall
+            val rows = (1..5).map { goalRelationship(it) }
+            var now = baseTime
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(rows.map(::positioned)),
+                entityUpdatedAtStats = InMemoryEntitySource(rows.map(::positioned)),
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                // above rows 1-3, below rows 4-5, so there is always work waiting beyond the boundary
+                safeBoundary = SafeBoundary { baseTime.plusSeconds(4) },
+                stallThreshold = Duration.ofHours(1),
+                clock = { now },
+                batchSize = 1,
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            repeat(3) {
+                now = now.plus(Duration.ofHours(1))
+                processor.processOneBatch() shouldBe Action.Continue
+            }
+        }
+
+        it("withholds a row sitting exactly on the boundary, because that is where an open transaction's rows sit") {
+            val onTheBoundary = goalRelationship(10)
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            val processor = processorFor(
+                listOf(onTheBoundary),
+                processed,
+                bookmarkStore,
+                safeBoundary = SafeBoundary { onTheBoundary.updatedAt },
+            )
+
+            processor.processOneBatch()
+
+            processed shouldBe emptyList()
+            bookmarkStore.saved shouldBe emptyList()
+        }
+
+        it("returns Continue when a full batch was processed, so the caller comes straight back") {
+            val goalRelationships = (1..3).map { goalRelationship(it) }
+            val processed = mutableListOf<GoalRelationship>()
+            val processor = processorFor(goalRelationships, processed, InMemoryEntityBookmarkStore(), batchSize = 3)
+
+            processor.processOneBatch() shouldBe Action.Continue
+        }
+
+        it("waits without processing anything when the bookmark lock can't be obtained") {
+            val processed = mutableListOf<GoalRelationship>()
+            val bookmarkStore = InMemoryEntityBookmarkStore(lockObtainable = false)
+
+            val action = processorFor(listOf(goalRelationship(1)), processed, bookmarkStore).processOneBatch()
+
+            action shouldBe Action.Wait
+            processed shouldBe emptyList()
+            bookmarkStore.saved shouldBe emptyList()
+        }
+
+        it("fails loudly when the source re-returns the row the bookmark is already at") {
+            val stuck = goalRelationship(1)
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            bookmarkStore.save("goal-relationships", stuck.position)
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = EntitySource.from { _, _, _ -> listOf(PositionedEntity(stuck, stuck.position)) },
+                entityUpdatedAtStats = EntityUpdatedAtStats.from { stuck.updatedAt },
+                bookmarkStore = bookmarkStore,
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                safeBoundary = wellAfterAnyRow,
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            shouldThrow<EntitySourceStalledException> { processor.processOneBatch() }
+        }
+
+        it("fails loudly when the source returns rows out of order") {
+            val earlier = goalRelationship(1)
+            val later = goalRelationship(2)
+            val processor = BatchedAsyncEntityProcessor(
+                entitySource = EntitySource.from { _, _, _ ->
+                    listOf(PositionedEntity(later, later.position), PositionedEntity(earlier, earlier.position))
+                },
+                entityUpdatedAtStats = EntityUpdatedAtStats.from { later.updatedAt },
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                safeBoundary = wellAfterAnyRow,
+                startLog = {},
+                endLog = { _, _ -> },
+            )
+
+            shouldThrow<EntitySourceOrderingException> { processor.processOneBatch() }
+        }
+
+        it("reports statistics for each entity processed") {
+            val goalRelationships = (1..2).map { goalRelationship(it) }
+            val collected = mutableListOf<PositionedEntity<*>>()
+            val stats = object : EntityStatisticsCollector {
+                override fun entityProcessed(processor: AsyncEntityProcessor<*>, entity: PositionedEntity<*>, durationMs: Long) {
+                    collected += entity
+                }
+            }
+            BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(goalRelationships.map(::positioned)),
+                entityUpdatedAtStats = InMemoryEntitySource(goalRelationships.map(::positioned)),
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+                safeBoundary = wellAfterAnyRow,
+                startLog = {},
+                endLog = { _, _ -> },
+                stats = stats,
+            ).processOneBatch()
+
+            collected.map { it.position } shouldBe goalRelationships.map { it.position }
+        }
+    }
+
+    describe("EntitySource.from") {
+        it("derives each row's position from the entity itself") {
+            val goalRelationships = (1..2).map { goalRelationship(it) }
+            val processed = mutableListOf<GoalRelationship>()
+
+            BatchedAsyncEntityProcessor(
+                entitySource = EntitySource.from({ it: GoalRelationship -> it.position }, { _, _, _ -> goalRelationships }),
+                entityUpdatedAtStats = EntityUpdatedAtStats.from { goalRelationships.last().updatedAt },
+                bookmarkStore = InMemoryEntityBookmarkStore(),
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.from { row: GoalRelationship -> processed += row },
+                safeBoundary = wellAfterAnyRow,
+                startLog = {},
+                endLog = { _, _ -> },
+            ).processOneBatch()
+
+            processed shouldBe goalRelationships
+        }
+    }
+
+    describe("EntityProcessor.compose") {
+        it("shares one bookmark across several processors") {
+            val goalRelationships = (1..2).map { goalRelationship(it) }
+            val first = mutableListOf<UUID>()
+            val second = mutableListOf<EntityPosition>()
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+
+            BatchedAsyncEntityProcessor(
+                entitySource = InMemoryEntitySource(goalRelationships.map(::positioned)),
+                entityUpdatedAtStats = InMemoryEntitySource(goalRelationships.map(::positioned)),
+                bookmarkStore = bookmarkStore,
+                bookmarkName = "goal-relationships",
+                entityProcessor = EntityProcessor.compose(
+                    EntityProcessor.from { goalRelationship: GoalRelationship -> first += goalRelationship.id },
+                    EntityProcessor.from { _: GoalRelationship, position: EntityPosition -> second += position },
+                ),
+                safeBoundary = wellAfterAnyRow,
+                startLog = {},
+                endLog = { _, _ -> },
+            ).processOneBatch()
+
+            first shouldBe goalRelationships.map { it.id }
+            second shouldBe goalRelationships.map { it.position }
+            bookmarkStore.bookmarkFor("goal-relationships").position shouldBe goalRelationships.last().position
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
@@ -19,15 +19,23 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
 
     fun positioned(goalRelationship: GoalRelationship) = PositionedEntity(goalRelationship, goalRelationship.position)
 
-    fun stallableProcessorFor(row: GoalRelationship, safeBoundary: SafeBoundary, clock: () -> LocalDateTime) = BatchedAsyncEntityProcessor(
-        entitySource = InMemoryEntitySource(listOf(positioned(row))),
-        entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(row))),
-        bookmarkStore = InMemoryEntityBookmarkStore(),
+    fun stallableProcessorFor(
+        rows: List<GoalRelationship>,
+        safeBoundary: SafeBoundary,
+        bookmarkStore: EntityBookmarkStore = InMemoryEntityBookmarkStore(),
+        stallBehaviour: StallBehaviour = StallBehaviour.Throw,
+        batchSize: Int = 1000,
+        processed: MutableList<GoalRelationship> = mutableListOf(),
+    ) = BatchedAsyncEntityProcessor(
+        entitySource = InMemoryEntitySource(rows.map(::positioned)),
+        entityUpdatedAtStats = InMemoryEntitySource(rows.map(::positioned)),
+        bookmarkStore = bookmarkStore,
         bookmarkName = "goal-relationships",
-        entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+        entityProcessor = EntityProcessor.from { row: GoalRelationship -> processed += row },
         safeBoundary = safeBoundary,
         stallThreshold = Duration.ofHours(1),
-        clock = clock,
+        stallBehaviour = stallBehaviour,
+        batchSize = batchSize,
         startLog = {},
         endLog = { _, _ -> },
     )
@@ -46,8 +54,6 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
         entityProcessor = EntityProcessor.from { goalRelationship: GoalRelationship -> processed += goalRelationship },
         safeBoundary = safeBoundary,
         batchSize = batchSize,
-        // anchored to the fixture timeline: against the real clock every boundary here would look years stale
-        clock = { baseTime },
         startLog = {},
         endLog = { _, _ -> },
     )
@@ -118,25 +124,17 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             processed shouldBe listOf(old, fresh)
         }
 
-        it("throws once the oldest open transaction has held the boundary back for longer than the stall threshold") {
-            val waiting = goalRelationship(10)
-            var now = baseTime
+        it("throws once the rows it cannot read span more than the stall threshold") {
+            // the boundary pinned at baseTime, as an open transaction started then would pin it, with two hours of
+            // writes stacked up above it
             val processor = stallableProcessorFor(
-                waiting,
-                // pinned well before the waiting row, as an open transaction would pin it
+                listOf(goalRelationship(secondsAfterBase = 2 * 60 * 60)),
                 safeBoundary = object : SafeBoundary {
                     override fun safeBefore() = baseTime
                     override fun describeBlockers() = "pid=999 application_name='psql' [UNRECOGNISED]"
                 },
-                clock = { now },
             )
 
-            // held back, but not yet for long enough to complain about
-            processor.processOneBatch() shouldBe Action.Wait
-            now = baseTime.plus(Duration.ofMinutes(59))
-            processor.processOneBatch() shouldBe Action.Wait
-
-            now = baseTime.plus(Duration.ofMinutes(61))
             val exception = shouldThrow<SafeBoundaryStalledException> { processor.processOneBatch() }
 
             // the report has to name the session to go and close, or it just says "publishing is behind"
@@ -144,46 +142,67 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             exception.message!! shouldContain "goal-relationships"
         }
 
-        it("says nothing while the boundary is keeping up with the clock") {
-            val waiting = goalRelationship(10)
-            var now = baseTime
+        it("says nothing while the rows it cannot read span less than the stall threshold") {
             val processor = stallableProcessorFor(
-                waiting,
-                // nothing is open, so the boundary tracks the database clock
-                safeBoundary = SafeBoundary { now.minusSeconds(1) },
-                clock = { now },
+                listOf(goalRelationship(secondsAfterBase = 59 * 60)),
+                safeBoundary = SafeBoundary { baseTime },
             )
 
-            processor.processOneBatch() shouldBe Action.Wait
-            now = baseTime.plus(Duration.ofDays(1))
             processor.processOneBatch() shouldBe Action.Wait
         }
 
-        it("logs and keeps processing under LogAndContinue, so a backfill behind an old boundary is not aborted") {
-            // the boundary can legitimately sit hours in the past, pinned by an unrelated transaction, while rows
-            // behind it are read perfectly happily
-            val rows = (1..3).map { goalRelationship(it) }
-            val processed = mutableListOf<GoalRelationship>()
-            val logged = mutableListOf<String>()
-            val processor = BatchedAsyncEntityProcessor(
-                entitySource = InMemoryEntitySource(rows.map(::positioned)),
-                entityUpdatedAtStats = InMemoryEntitySource(rows.map(::positioned)),
-                bookmarkStore = InMemoryEntityBookmarkStore(),
-                bookmarkName = "goal-relationships",
-                entityProcessor = EntityProcessor.from { row: GoalRelationship -> processed += row },
-                safeBoundary = SafeBoundary { baseTime.minus(Duration.ofHours(5)) },
-                stallThreshold = Duration.ofHours(1),
-                stallBehaviour = StallBehaviour.LogAndContinue { logged += it },
-                clock = { baseTime },
-                batchSize = 1,
-                startLog = {},
-                endLog = { _, _ -> },
+        it("says nothing when it has nothing to do, however far behind the boundary is") {
+            // an idle table is not a stall: its newest row is behind the boundary, so nothing is being forbidden
+            val done = goalRelationship(1)
+            val bookmarkStore = InMemoryEntityBookmarkStore()
+            bookmarkStore.save("goal-relationships", done.position)
+            val processor = stallableProcessorFor(
+                listOf(done),
+                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(5)) },
+                bookmarkStore = bookmarkStore,
             )
 
-            repeat(2) { processor.processOneBatch() }
+            processor.processOneBatch() shouldBe Action.Wait
+        }
 
-            logged.size shouldBe 2
-            logged.first() shouldContain "goal-relationships"
+        it("says nothing while it is still making progress, however far the head is beyond the boundary") {
+            // the backfill case: rows readable below a boundary an unrelated transaction has pinned hours back. The
+            // state is otherwise identical to a stall, so what discriminates is only whether a batch read anything.
+            val readable = (1..3).map { goalRelationship(it) }
+            val blocked = goalRelationship(secondsAfterBase = 3 * 60 * 60)
+            val processor = stallableProcessorFor(
+                readable + blocked,
+                safeBoundary = SafeBoundary { baseTime.plusSeconds(4) },
+                batchSize = 1,
+            )
+
+            repeat(3) { processor.processOneBatch() shouldBe Action.Continue }
+
+            // and now that there is nothing left below the boundary, the same state does report
+            shouldThrow<SafeBoundaryStalledException> { processor.processOneBatch() }
+        }
+
+        it("logs instead of throwing under LogAndContinue, and picks the rows up once the boundary passes them") {
+            val waiting = goalRelationship(secondsAfterBase = 2 * 60 * 60)
+            val logged = mutableListOf<String>()
+            val processed = mutableListOf<GoalRelationship>()
+            var boundary = baseTime
+            val processor = stallableProcessorFor(
+                listOf(waiting),
+                safeBoundary = SafeBoundary { boundary },
+                stallBehaviour = StallBehaviour.LogAndContinue { logged += it },
+                processed = processed,
+            )
+
+            processor.processOneBatch() shouldBe Action.Wait
+            logged.size shouldBe 1
+            logged.single() shouldContain "goal-relationships"
+
+            boundary = waiting.updatedAt.plusSeconds(1)
+            processor.processOneBatch() shouldBe Action.Wait
+
+            processed shouldBe listOf(waiting)
+            logged.size shouldBe 1
         }
 
         it("withholds a row sitting exactly on the boundary, because that is where an open transaction's rows sit") {
@@ -233,7 +252,6 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
-                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             )
@@ -253,7 +271,6 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
-                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             )
@@ -276,7 +293,6 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
-                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
                 stats = stats,
@@ -303,7 +319,6 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                     EntityProcessor.from { _: GoalRelationship, position: EntityPosition -> second += position },
                 ),
                 safeBoundary = wellAfterAnyRow,
-                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             ).processOneBatch()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
@@ -19,6 +19,19 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
 
     fun positioned(goalRelationship: GoalRelationship) = PositionedEntity(goalRelationship, goalRelationship.position)
 
+    fun stallableProcessorFor(row: GoalRelationship, safeBoundary: SafeBoundary, clock: () -> LocalDateTime) = BatchedAsyncEntityProcessor(
+        entitySource = InMemoryEntitySource(listOf(positioned(row))),
+        entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(row))),
+        bookmarkStore = InMemoryEntityBookmarkStore(),
+        bookmarkName = "goal-relationships",
+        entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+        safeBoundary = safeBoundary,
+        stallThreshold = Duration.ofHours(1),
+        clock = clock,
+        startLog = {},
+        endLog = { _, _ -> },
+    )
+
     fun processorFor(
         goalRelationships: List<GoalRelationship>,
         processed: MutableList<GoalRelationship>,
@@ -33,6 +46,8 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
         entityProcessor = EntityProcessor.from { goalRelationship: GoalRelationship -> processed += goalRelationship },
         safeBoundary = safeBoundary,
         batchSize = batchSize,
+        // anchored to the fixture timeline: against the real clock every boundary here would look years stale
+        clock = { baseTime },
         startLog = {},
         endLog = { _, _ -> },
     )
@@ -103,24 +118,17 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             processed shouldBe listOf(old, fresh)
         }
 
-        it("throws once it has been held back by the boundary for longer than the stall threshold") {
+        it("throws once the oldest open transaction has held the boundary back for longer than the stall threshold") {
             val waiting = goalRelationship(10)
             var now = baseTime
-            val processor = BatchedAsyncEntityProcessor(
-                entitySource = InMemoryEntitySource(listOf(positioned(waiting))),
-                entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(waiting))),
-                bookmarkStore = InMemoryEntityBookmarkStore(),
-                bookmarkName = "goal-relationships",
-                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
+            val processor = stallableProcessorFor(
+                waiting,
                 // pinned well before the waiting row, as an open transaction would pin it
                 safeBoundary = object : SafeBoundary {
                     override fun safeBefore() = baseTime
                     override fun describeBlockers() = "pid=999 application_name='psql' [UNRECOGNISED]"
                 },
-                stallThreshold = Duration.ofHours(1),
                 clock = { now },
-                startLog = {},
-                endLog = { _, _ -> },
             )
 
             // held back, but not yet for long enough to complain about
@@ -136,54 +144,46 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
             exception.message!! shouldContain "goal-relationships"
         }
 
-        it("does not throw when it has nothing to do, however old the boundary is") {
-            // an idle table is not a stall: everything in it is already behind the boundary
-            val done = goalRelationship(1)
-            val bookmarkStore = InMemoryEntityBookmarkStore()
-            bookmarkStore.save("goal-relationships", done.position)
+        it("says nothing while the boundary is keeping up with the clock") {
+            val waiting = goalRelationship(10)
             var now = baseTime
-            val processor = BatchedAsyncEntityProcessor(
-                entitySource = InMemoryEntitySource(listOf(positioned(done))),
-                entityUpdatedAtStats = InMemoryEntitySource(listOf(positioned(done))),
-                bookmarkStore = bookmarkStore,
-                bookmarkName = "goal-relationships",
-                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
-                safeBoundary = SafeBoundary { baseTime.plus(Duration.ofHours(5)) },
-                stallThreshold = Duration.ofHours(1),
+            val processor = stallableProcessorFor(
+                waiting,
+                // nothing is open, so the boundary tracks the database clock
+                safeBoundary = SafeBoundary { now.minusSeconds(1) },
                 clock = { now },
-                startLog = {},
-                endLog = { _, _ -> },
             )
 
-            processor.processOneBatch()
+            processor.processOneBatch() shouldBe Action.Wait
             now = baseTime.plus(Duration.ofDays(1))
-
             processor.processOneBatch() shouldBe Action.Wait
         }
 
-        it("does not throw while it is still making progress, however far behind the boundary is") {
-            // the backfill case: an old boundary while rows behind it are read happily is not a stall
-            val rows = (1..5).map { goalRelationship(it) }
-            var now = baseTime
+        it("logs and keeps processing under LogAndContinue, so a backfill behind an old boundary is not aborted") {
+            // the boundary can legitimately sit hours in the past, pinned by an unrelated transaction, while rows
+            // behind it are read perfectly happily
+            val rows = (1..3).map { goalRelationship(it) }
+            val processed = mutableListOf<GoalRelationship>()
+            val logged = mutableListOf<String>()
             val processor = BatchedAsyncEntityProcessor(
                 entitySource = InMemoryEntitySource(rows.map(::positioned)),
                 entityUpdatedAtStats = InMemoryEntitySource(rows.map(::positioned)),
                 bookmarkStore = InMemoryEntityBookmarkStore(),
                 bookmarkName = "goal-relationships",
-                entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
-                // above rows 1-3, below rows 4-5, so there is always work waiting beyond the boundary
-                safeBoundary = SafeBoundary { baseTime.plusSeconds(4) },
+                entityProcessor = EntityProcessor.from { row: GoalRelationship -> processed += row },
+                safeBoundary = SafeBoundary { baseTime.minus(Duration.ofHours(5)) },
                 stallThreshold = Duration.ofHours(1),
-                clock = { now },
+                stallBehaviour = StallBehaviour.LogAndContinue { logged += it },
+                clock = { baseTime },
                 batchSize = 1,
                 startLog = {},
                 endLog = { _, _ -> },
             )
 
-            repeat(3) {
-                now = now.plus(Duration.ofHours(1))
-                processor.processOneBatch() shouldBe Action.Continue
-            }
+            repeat(2) { processor.processOneBatch() }
+
+            logged.size shouldBe 2
+            logged.first() shouldContain "goal-relationships"
         }
 
         it("withholds a row sitting exactly on the boundary, because that is where an open transaction's rows sit") {
@@ -233,6 +233,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
+                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             )
@@ -252,6 +253,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
+                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             )
@@ -274,32 +276,13 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 bookmarkName = "goal-relationships",
                 entityProcessor = EntityProcessor.from { _: GoalRelationship -> },
                 safeBoundary = wellAfterAnyRow,
+                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
                 stats = stats,
             ).processOneBatch()
 
             collected.map { it.position } shouldBe goalRelationships.map { it.position }
-        }
-    }
-
-    describe("EntitySource.from") {
-        it("derives each row's position from the entity itself") {
-            val goalRelationships = (1..2).map { goalRelationship(it) }
-            val processed = mutableListOf<GoalRelationship>()
-
-            BatchedAsyncEntityProcessor(
-                entitySource = EntitySource.from({ it: GoalRelationship -> it.position }, { _, _, _ -> goalRelationships }),
-                entityUpdatedAtStats = EntityUpdatedAtStats.from { goalRelationships.last().updatedAt },
-                bookmarkStore = InMemoryEntityBookmarkStore(),
-                bookmarkName = "goal-relationships",
-                entityProcessor = EntityProcessor.from { row: GoalRelationship -> processed += row },
-                safeBoundary = wellAfterAnyRow,
-                startLog = {},
-                endLog = { _, _ -> },
-            ).processOneBatch()
-
-            processed shouldBe goalRelationships
         }
     }
 
@@ -320,6 +303,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                     EntityProcessor.from { _: GoalRelationship, position: EntityPosition -> second += position },
                 ),
                 safeBoundary = wellAfterAnyRow,
+                clock = { baseTime },
                 startLog = {},
                 endLog = { _, _ -> },
             ).processOneBatch()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/BatchedAsyncEntityProcessorTest.kt
@@ -121,7 +121,7 @@ class BatchedAsyncEntityProcessorTest : DescribeSpec({
                 listOf(old, fresh),
                 processed,
                 bookmarkStore,
-                safeBoundary = SafeBoundary.unsafeFixedDelay(Duration.ofMillis(1000)) { now },
+                safeBoundary = SafeBoundary { SafeBoundaryReading(safeBefore = now.minus(Duration.ofMillis(1000)), readAt = now) },
             )
 
             processor.processOneBatch()

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EntityPositionTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EntityPositionTest.kt
@@ -1,0 +1,64 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import java.util.UUID
+
+class EntityPositionTest : DescribeSpec({
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+    val id = UUID.randomUUID()
+
+    describe("compareTo") {
+        it("orders on updated-at first") {
+            val earlier = EntityPosition(baseTime, UUID.fromString("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+            val later = EntityPosition(baseTime.plusSeconds(1), UUID.fromString("00000000-0000-0000-0000-000000000000"))
+
+            (earlier < later) shouldBe true
+        }
+
+        it("distinguishes positions differing only below the millisecond") {
+            val earlier = EntityPosition(baseTime.plusNanos(123_000_000), id)
+            val later = EntityPosition(baseTime.plusNanos(123_456_000), id)
+
+            (earlier < later) shouldBe true
+            earlier shouldBe earlier.copy()
+        }
+
+        it("tiebreaks on id as an unsigned 128-bit value, matching how Postgres orders uuids") {
+            // 0x7f... is signed-positive and 0x80... signed-negative, so a signed comparison would order these the
+            // other way around
+            val lower = EntityPosition(baseTime, UUID.fromString("7fffffff-ffff-ffff-ffff-ffffffffffff"))
+            val higher = EntityPosition(baseTime, UUID.fromString("80000000-0000-0000-0000-000000000000"))
+
+            (lower < higher) shouldBe true
+        }
+
+        it("tiebreaks on the least significant bits when the most significant are equal") {
+            val lower = EntityPosition(baseTime, UUID.fromString("00000000-0000-0000-7fff-ffffffffffff"))
+            val higher = EntityPosition(baseTime, UUID.fromString("00000000-0000-0000-8000-000000000000"))
+
+            (lower < higher) shouldBe true
+        }
+    }
+
+    describe("equality") {
+        it("agrees with compareTo, which is what bookmark comparisons rely on") {
+            val position = EntityPosition(baseTime.plusNanos(123_456_000), id)
+            val same = EntityPosition(baseTime.plusNanos(123_456_000), id)
+
+            position shouldBe same
+            position.compareTo(same) shouldBe 0
+            position.hashCode() shouldBe same.hashCode()
+        }
+
+        it("is not equal when only the id differs") {
+            EntityPosition(baseTime, id) shouldBe EntityPosition(baseTime, id)
+            (EntityPosition(baseTime, id) == EntityPosition(baseTime, UUID.randomUUID())) shouldBe false
+        }
+
+        it("is not equal when only the updated-at differs") {
+            (EntityPosition(baseTime, id) == EntityPosition(baseTime.plusNanos(1), id)) shouldBe false
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/EntityTestFixtures.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/EntityTestFixtures.kt
@@ -1,0 +1,84 @@
+package com.cultureamp.eventsourcing
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.java.javaUUID
+import org.jetbrains.exposed.v1.javatime.datetime
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.UUID
+
+/** A value for the fixture's non-position timestamp columns. */
+val fixtureCreatedAt: LocalDateTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+
+/**
+ * Mirrors the real table:
+ *
+ * ```
+ * CREATE TABLE public.goal_relationships (
+ *     id                uuid NOT NULL,
+ *     child_goal_id     uuid NOT NULL,
+ *     parent_goal_id    uuid NOT NULL,
+ *     account_id        uuid NOT NULL,
+ *     created_at        timestamp without time zone NOT NULL,
+ *     updated_at        timestamp without time zone NOT NULL,
+ *     deleted_at        timestamp without time zone,
+ *     cascading_weight  numeric(5,4) DEFAULT 0 NOT NULL
+ * );
+ * ```
+ *
+ * Every timestamp is naive and holds UTC, `updated_at` — the position column — included.
+ */
+class GoalRelationshipsTable(tableName: String = "goal_relationships") : Table(tableName) {
+    val id = javaUUID("id")
+    val childGoalId = javaUUID("child_goal_id")
+    val parentGoalId = javaUUID("parent_goal_id")
+    val accountId = javaUUID("account_id")
+    val createdAt = datetime("created_at")
+    val updatedAt = datetime("updated_at")
+    val deletedAt = datetime("deleted_at").nullable()
+    val cascadingWeight = decimal("cascading_weight", precision = 5, scale = 4).default(BigDecimal("0.0000"))
+    override val primaryKey = PrimaryKey(id)
+}
+
+data class GoalRelationship(
+    val id: UUID,
+    val childGoalId: UUID,
+    val parentGoalId: UUID,
+    val accountId: UUID,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val deletedAt: LocalDateTime? = null,
+    val cascadingWeight: BigDecimal = BigDecimal("0.0000"),
+) {
+    val position = EntityPosition(updatedAt, id)
+}
+
+class InMemoryEntityBookmarkStore(private val lockObtainable: Boolean = true) : EntityBookmarkStore {
+    private val positions = mutableMapOf<String, EntityPosition>()
+    val saved = mutableListOf<EntityBookmark>()
+
+    override fun bookmarkFor(bookmarkName: String) = EntityBookmark(bookmarkName, positions[bookmarkName])
+
+    override fun bookmarksFor(bookmarkNames: Set<String>) = bookmarkNames.map { bookmarkFor(it) }.toSet()
+
+    override fun save(bookmarkName: String, position: EntityPosition) {
+        positions[bookmarkName] = position
+        saved += EntityBookmark(bookmarkName, position)
+    }
+
+    override fun checkoutBookmark(bookmarkName: String): Either<LockNotObtained, EntityBookmark> =
+        if (lockObtainable) Right(bookmarkFor(bookmarkName)) else Left(LockNotObtained)
+}
+
+/**
+ * A well-behaved [EntitySource] over a fixed list of rows, honouring the ordering, `after` and `safeBefore` contract.
+ */
+class InMemoryEntitySource<E>(private val rows: List<PositionedEntity<E>>) : EntitySource<E>, EntityUpdatedAtStats {
+    // `isBefore`, not `!isAfter`: the boundary is exclusive, matching RelationalDatabaseEntitySource
+    override fun getAfter(after: EntityPosition?, safeBefore: LocalDateTime, batchSize: Int) = rows
+        .sortedBy { it.position }
+        .filter { (after == null || it.position > after) && it.position.updatedAt.isBefore(safeBefore) }
+        .take(batchSize)
+
+    override fun lastUpdatedAt() = rows.maxByOrNull { it.position }?.position?.updatedAt
+}

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PostgresXactStartSafeBoundaryTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PostgresXactStartSafeBoundaryTest.kt
@@ -1,0 +1,292 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.testcontainers.containers.PostgreSQLContainer
+import java.sql.Connection
+import java.sql.DriverManager
+import java.time.LocalDateTime
+
+/**
+ * Where the Postgres under test comes from. Testcontainers by default, so this runs in CI unattended; an existing
+ * database if `KESTREL_TEST_PG_URL` is set, so it can also be run where Docker is unavailable.
+ */
+private data class PostgresTarget(val jdbcUrl: String, val username: String, val password: String) {
+    /**
+     * The same server, a different database. Used to put a reader somewhere no other client backend is connected, so
+     * the only redacted rows it can see are the auxiliary processes.
+     */
+    fun withDatabase(name: String): PostgresTarget {
+        val query = jdbcUrl.substringAfter('?', "").let { if (it.isEmpty()) "" else "?$it" }
+        return copy(jdbcUrl = "${jdbcUrl.substringBefore('?').substringBeforeLast('/')}/$name$query")
+    }
+
+    companion object {
+        fun resolve(): PostgresTarget = System.getenv("KESTREL_TEST_PG_URL")?.let {
+            PostgresTarget(it, System.getenv("KESTREL_TEST_PG_USER") ?: "postgres", System.getenv("KESTREL_TEST_PG_PASSWORD") ?: "")
+        } ?: PostgreSQLContainer("postgres:14.3").let { container ->
+            container.start()
+            PostgresTarget(container.jdbcUrl, container.username, container.password)
+        }
+    }
+}
+
+/**
+ * Needs a real Postgres, since the whole mechanism is `pg_stat_activity` and H2 has no equivalent.
+ *
+ * The role this connects as must be able to see other backends' `xact_start` — a superuser, or a member of
+ * `pg_read_all_stats`. That is not incidental to the test setup: it is the deployment requirement the boundary asserts,
+ * and one of the cases below covers what happens when it does not hold.
+ */
+class PostgresXactStartSafeBoundaryTest : DescribeSpec({
+    val postgres = PostgresTarget.resolve()
+    val db = Database.connect(
+        url = postgres.jdbcUrl,
+        driver = "org.postgresql.Driver",
+        user = postgres.username,
+        password = postgres.password,
+    )
+
+    val safeBoundary = PostgresXactStartSafeBoundary(db)
+
+    // `AT TIME ZONE 'UTC'` throughout, so these read the same naive UTC timestamps the boundary reports.
+    fun databaseNow(): LocalDateTime = transaction(db) {
+        exec("SELECT clock_timestamp() AT TIME ZONE 'UTC'") { rs ->
+            rs.next()
+            rs.getObject(1, LocalDateTime::class.java)
+        }!!
+    }
+
+    /**
+     * Opens a transaction on its own connection and leaves it open, returning the connection and the `xact_start`
+     * Postgres assigned it. The `SELECT 1` matters: with autocommit off, JDBC only begins the transaction — and so only
+     * sets `xact_start` — on the first statement.
+     */
+    fun openTransaction(): Pair<Connection, LocalDateTime> {
+        val connection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+        connection.autoCommit = false
+        connection.createStatement().use { it.executeQuery("SELECT 1").close() }
+        val xactStart = connection.createStatement().use { statement ->
+            statement.executeQuery("SELECT xact_start AT TIME ZONE 'UTC' FROM pg_stat_activity WHERE pid = pg_backend_pid()").use { rs ->
+                rs.next()
+                rs.getObject(1, LocalDateTime::class.java)
+            }
+        }
+        return connection to xactStart
+    }
+
+    /**
+     * An unprivileged role to read `pg_stat_activity` as, so the redaction cases below see what a reader without
+     * `pg_read_all_stats` sees. Dropped and recreated rather than assuming a clean database, since this spec can be
+     * pointed at a persistent one; a role holding privileges cannot simply be dropped, so revoke first. Nothing is
+     * granted to it — PUBLIC holds CONNECT — which keeps it dependency-free and so always droppable.
+     */
+    fun recreateLimitedRole() {
+        transaction(db) {
+            exec(
+                """
+                DO ${'$'}${'$'}
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'boundary_limited') THEN
+                        EXECUTE 'REVOKE ALL ON DATABASE ' || quote_ident(current_database()) || ' FROM boundary_limited';
+                        EXECUTE 'DROP ROLE boundary_limited';
+                    END IF;
+                END
+                ${'$'}${'$'};
+                """.trimIndent(),
+            )
+            exec("CREATE ROLE boundary_limited LOGIN PASSWORD 'limited'")
+        }
+    }
+
+    fun limitedConnectionTo(target: PostgresTarget): Database = Database.connect(
+        url = target.jdbcUrl,
+        driver = "org.postgresql.Driver",
+        user = "boundary_limited",
+        password = "limited",
+    )
+
+    describe("safeBefore") {
+        it("tracks the database clock when nothing else is open") {
+            val before = databaseNow()
+            val boundary = safeBoundary.safeBefore()
+            val after = databaseNow()
+
+            // nothing else is open, so everything committed is visible and the boundary is simply "now"
+            boundary.isAfter(before).shouldBeTrue()
+            boundary.isBefore(after).shouldBeTrue()
+        }
+
+        it("never advances past the start of an open transaction, and does once it commits") {
+            val (connection, xactStart) = openTransaction()
+
+            try {
+                // Equality is the expected result, and is safe only because the boundary is exclusive: a row stamped at
+                // exactly this xact_start is still excluded by `updated_at < safeBefore`.
+                safeBoundary.safeBefore() shouldBeLessThanOrEqualTo xactStart
+            } finally {
+                connection.commit()
+                connection.close()
+            }
+
+            safeBoundary.safeBefore() shouldBeGreaterThanOrEqualTo xactStart
+        }
+
+        it("holds the boundary at the oldest open transaction, not the newest") {
+            val (oldest, oldestXactStart) = openTransaction()
+            val (newer, newerXactStart) = openTransaction()
+
+            try {
+                newerXactStart shouldBeGreaterThanOrEqualTo oldestXactStart
+                safeBoundary.safeBefore() shouldBeLessThanOrEqualTo oldestXactStart
+            } finally {
+                listOf(oldest, newer).forEach {
+                    it.commit()
+                    it.close()
+                }
+            }
+        }
+
+        it("ignores the reader's own transaction, so an idle database still advances") {
+            // The boundary read is itself a transaction, and counting itself would pin the boundary to its own start.
+            val first = safeBoundary.safeBefore()
+            val second = safeBoundary.safeBefore()
+
+            second shouldBeGreaterThanOrEqualTo first
+        }
+
+        it("caps the boundary at the start of its own read, excluding any transaction it could not have seen") {
+            // A transaction beginning after the boundary read is absent from its snapshot. What makes that safe is the
+            // statement_timestamp() cap: the transaction's xact_start, and so every row it stamps, is above the cap.
+            val boundary = safeBoundary.safeBefore()
+            val (connection, xactStart) = openTransaction()
+
+            try {
+                xactStart shouldBeGreaterThanOrEqualTo boundary
+            } finally {
+                connection.commit()
+                connection.close()
+            }
+        }
+
+        it("is not computed from a stale backend-status snapshot") {
+            // pg_stat_activity is cached for the whole reading transaction, so without the pg_stat_clear_snapshot()
+            // in safeBefore() a caller that had already read it would get a boundary from a view missing the
+            // transaction opened below.
+            transaction(db) {
+                // Populate this transaction's snapshot before the transaction below exists. Exposed joins the nested
+                // transaction inside safeBefore() to this one, so the boundary is read with that snapshot in place.
+                exec("SELECT count(*) FROM pg_stat_activity") { rs -> rs.next() }
+
+                val (connection, xactStart) = openTransaction()
+
+                try {
+                    safeBoundary.safeBefore() shouldBeLessThanOrEqualTo xactStart
+                } finally {
+                    connection.commit()
+                    connection.close()
+                }
+            }
+        }
+
+        it("names the open transactions holding it back, tagging ours from anyone else's") {
+            // application_name is self-reported, so it is only ever a diagnostic, never an input to the boundary.
+            val connection = DriverManager.getConnection(
+                "${postgres.jdbcUrl}${if (postgres.jdbcUrl.contains('?')) "&" else "?"}ApplicationName=some-service",
+                postgres.username,
+                postgres.password,
+            )
+            try {
+                connection.autoCommit = false
+                connection.createStatement().use { it.executeQuery("SELECT 1").close() }
+
+                PostgresXactStartSafeBoundary(db, knownApplicationNames = setOf("some-service"))
+                    .describeBlockers() shouldContain "application_name='some-service' [known]"
+
+                PostgresXactStartSafeBoundary(db, knownApplicationNames = emptySet())
+                    .describeBlockers() shouldContain "application_name='some-service' [UNRECOGNISED]"
+            } finally {
+                connection.commit()
+                connection.close()
+            }
+        }
+
+        it("does not put query text into the diagnosis, which would carry row data into an error tracker") {
+            val connection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
+            try {
+                connection.autoCommit = false
+                connection.createStatement().use { it.executeQuery("SELECT 'sensitive-row-value-42'").close() }
+
+                safeBoundary.describeBlockers() shouldNotContain "sensitive-row-value-42"
+            } finally {
+                connection.commit()
+                connection.close()
+            }
+        }
+
+        it("says so plainly when nothing is holding it back") {
+            safeBoundary.describeBlockers() shouldContain "no open transactions found"
+        }
+
+        it("refuses to report a boundary when pg_stat_activity is hiding backends in this database") {
+            // An unprivileged role sees other roles' backends with xact_start nulled, so min(xact_start) collapses to
+            // its own transactions — failing open into the bug the boundary exists to close. The transaction opened
+            // below is what makes this dangerous rather than merely under-privileged: a real one, in this database,
+            // that the reader cannot see.
+            recreateLimitedRole()
+            val limitedDb = limitedConnectionTo(postgres)
+            val (connection, _) = openTransaction()
+
+            try {
+                // the fail-open itself: to this reader no transaction is open anywhere, while one demonstrably is
+                transaction(limitedDb) {
+                    exec(
+                        "SELECT count(*) FROM pg_stat_activity " +
+                            "WHERE xact_start IS NOT NULL AND pid <> pg_backend_pid()",
+                    ) { rs ->
+                        rs.next()
+                        rs.getInt(1)
+                    }
+                } shouldBe 0
+
+                val exception = shouldThrow<SafeBoundaryUnreliableException> {
+                    PostgresXactStartSafeBoundary(limitedDb).safeBefore()
+                }
+
+                exception.message!! shouldContain "hidden from this connection"
+            } finally {
+                connection.commit()
+                connection.close()
+            }
+        }
+
+        it("still reports a boundary when the only hidden backends are auxiliary processes") {
+            // Redaction hides the auxiliary processes too, and nothing short of pg_read_all_stats reveals them — so
+            // counting them would leave the check permanently unsatisfiable. They report no database, which is why the
+            // count is scoped to the reader's own. Read here from a database nothing else is connected to, so they are
+            // the only redacted rows present.
+            recreateLimitedRole()
+            DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password).use { admin ->
+                admin.createStatement().use {
+                    it.execute("DROP DATABASE IF EXISTS boundary_isolated")
+                    it.execute("CREATE DATABASE boundary_isolated")
+                }
+            }
+            val isolatedDb = limitedConnectionTo(postgres.withDatabase("boundary_isolated"))
+
+            val before = databaseNow()
+            val boundary = PostgresXactStartSafeBoundary(isolatedDb).safeBefore()
+
+            // nothing is open in that database, so the boundary is simply the reader's own statement_timestamp()
+            boundary shouldBeGreaterThanOrEqualTo before
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/PostgresXactStartSafeBoundaryTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/PostgresXactStartSafeBoundaryTest.kt
@@ -117,7 +117,7 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
     describe("safeBefore") {
         it("tracks the database clock when nothing else is open") {
             val before = databaseNow()
-            val boundary = safeBoundary.safeBefore()
+            val boundary = safeBoundary.read().safeBefore
             val after = databaseNow()
 
             // nothing else is open, so everything committed is visible and the boundary is simply "now"
@@ -131,13 +131,31 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
             try {
                 // Equality is the expected result, and is safe only because the boundary is exclusive: a row stamped at
                 // exactly this xact_start is still excluded by `updated_at < safeBefore`.
-                safeBoundary.safeBefore() shouldBeLessThanOrEqualTo xactStart
+                safeBoundary.read().safeBefore shouldBeLessThanOrEqualTo xactStart
             } finally {
                 connection.commit()
                 connection.close()
             }
 
-            safeBoundary.safeBefore() shouldBeGreaterThanOrEqualTo xactStart
+            safeBoundary.read().safeBefore shouldBeGreaterThanOrEqualTo xactStart
+        }
+
+        it("reports when it read the boundary, so its age is measurable without an application clock") {
+            val (connection, xactStart) = openTransaction()
+
+            try {
+                val before = databaseNow()
+                val reading = safeBoundary.read()
+                val after = databaseNow()
+
+                // pinned at the open transaction, but read now: the gap is how long that transaction has been open
+                reading.safeBefore shouldBeLessThanOrEqualTo xactStart
+                reading.readAt shouldBeGreaterThanOrEqualTo before
+                reading.readAt shouldBeLessThanOrEqualTo after
+            } finally {
+                connection.commit()
+                connection.close()
+            }
         }
 
         it("holds the boundary at the oldest open transaction, not the newest") {
@@ -146,7 +164,7 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
 
             try {
                 newerXactStart shouldBeGreaterThanOrEqualTo oldestXactStart
-                safeBoundary.safeBefore() shouldBeLessThanOrEqualTo oldestXactStart
+                safeBoundary.read().safeBefore shouldBeLessThanOrEqualTo oldestXactStart
             } finally {
                 listOf(oldest, newer).forEach {
                     it.commit()
@@ -157,8 +175,8 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
 
         it("ignores the reader's own transaction, so an idle database still advances") {
             // The boundary read is itself a transaction, and counting itself would pin the boundary to its own start.
-            val first = safeBoundary.safeBefore()
-            val second = safeBoundary.safeBefore()
+            val first = safeBoundary.read().safeBefore
+            val second = safeBoundary.read().safeBefore
 
             second shouldBeGreaterThanOrEqualTo first
         }
@@ -166,7 +184,7 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
         it("caps the boundary at the start of its own read, excluding any transaction it could not have seen") {
             // A transaction beginning after the boundary read is absent from its snapshot. What makes that safe is the
             // statement_timestamp() cap: the transaction's xact_start, and so every row it stamps, is above the cap.
-            val boundary = safeBoundary.safeBefore()
+            val boundary = safeBoundary.read().safeBefore
             val (connection, xactStart) = openTransaction()
 
             try {
@@ -179,17 +197,17 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
 
         it("is not computed from a stale backend-status snapshot") {
             // pg_stat_activity is cached for the whole reading transaction, so without the pg_stat_clear_snapshot()
-            // in safeBefore() a caller that had already read it would get a boundary from a view missing the
+            // in read() a caller that had already read it would get a boundary from a view missing the
             // transaction opened below.
             transaction(db) {
                 // Populate this transaction's snapshot before the transaction below exists. Exposed joins the nested
-                // transaction inside safeBefore() to this one, so the boundary is read with that snapshot in place.
+                // transaction inside read() to this one, so the boundary is read with that snapshot in place.
                 exec("SELECT count(*) FROM pg_stat_activity") { rs -> rs.next() }
 
                 val (connection, xactStart) = openTransaction()
 
                 try {
-                    safeBoundary.safeBefore() shouldBeLessThanOrEqualTo xactStart
+                    safeBoundary.read().safeBefore shouldBeLessThanOrEqualTo xactStart
                 } finally {
                     connection.commit()
                     connection.close()
@@ -258,7 +276,7 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
                 } shouldBe 0
 
                 val exception = shouldThrow<SafeBoundaryUnreliableException> {
-                    PostgresXactStartSafeBoundary(limitedDb).safeBefore()
+                    PostgresXactStartSafeBoundary(limitedDb).read()
                 }
 
                 exception.message!! shouldContain "hidden from this connection"
@@ -283,7 +301,7 @@ class PostgresXactStartSafeBoundaryTest : DescribeSpec({
             val isolatedDb = limitedConnectionTo(postgres.withDatabase("boundary_isolated"))
 
             val before = databaseNow()
-            val boundary = PostgresXactStartSafeBoundary(isolatedDb).safeBefore()
+            val boundary = PostgresXactStartSafeBoundary(isolatedDb).read().safeBefore
 
             // nothing is open in that database, so the boundary is simply the reader's own statement_timestamp()
             boundary shouldBeGreaterThanOrEqualTo before

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntityBookmarkStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntityBookmarkStoreTest.kt
@@ -1,0 +1,74 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+class RelationalDatabaseEntityBookmarkStoreTest : DescribeSpec({
+    val db = PgTestConfig.db ?: Database.connect(url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    val store = RelationalDatabaseEntityBookmarkStore(db)
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+
+    beforeTest {
+        store.createSchemaIfNotExists()
+    }
+
+    afterTest {
+        transaction(db) {
+            SchemaUtils.drop(store.table)
+        }
+    }
+
+    describe("RelationalDatabaseEntityBookmarkStore") {
+        it("sets and retrieves a bookmark position") {
+            val position = EntityPosition(baseTime, UUID.randomUUID())
+            store.save("new-bookmark", position)
+            store.save("other-bookmark", EntityPosition(baseTime.plusSeconds(1), UUID.randomUUID()))
+
+            store.bookmarkFor("new-bookmark") shouldBe EntityBookmark("new-bookmark", position)
+        }
+
+        it("returns a null position for an unknown bookmark") {
+            store.bookmarkFor("other-new-bookmark") shouldBe EntityBookmark("other-new-bookmark", null)
+        }
+
+        it("updates the position if the bookmark already exists") {
+            val first = EntityPosition(baseTime, UUID.randomUUID())
+            val second = EntityPosition(baseTime.plus(Duration.ofHours(1)), UUID.randomUUID())
+            store.save("update-bookmark", first)
+            store.save("other-bookmark", EntityPosition(baseTime, UUID.randomUUID()))
+            store.save("update-bookmark", second)
+
+            store.bookmarkFor("update-bookmark") shouldBe EntityBookmark("update-bookmark", second)
+        }
+
+        it("can fetch bookmarks in bulk") {
+            val position = EntityPosition(baseTime, UUID.randomUUID())
+            val otherPosition = EntityPosition(baseTime.plusSeconds(1), UUID.randomUUID())
+            store.save("new-bookmark", position)
+            store.save("other-bookmark", otherPosition)
+
+            val bookmarks = store.bookmarksFor(setOf("new-bookmark", "other-bookmark", "unknown-bookmark"))
+
+            bookmarks shouldBe setOf(
+                EntityBookmark("new-bookmark", position),
+                EntityBookmark("other-bookmark", otherPosition),
+                EntityBookmark("unknown-bookmark", null),
+            )
+        }
+
+        it("checks out a bookmark, obtaining the lock") {
+            val position = EntityPosition(baseTime, UUID.randomUUID())
+            store.save("checkout-bookmark", position)
+
+            val checkedOut = store.checkoutBookmark("checkout-bookmark")
+
+            (checkedOut as Right).value shouldBe EntityBookmark("checkout-bookmark", position)
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntityBookmarkStoreTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntityBookmarkStoreTest.kt
@@ -62,6 +62,20 @@ class RelationalDatabaseEntityBookmarkStoreTest : DescribeSpec({
             )
         }
 
+        it("namespaces the name it locks on, so it cannot lock out an event-bookmark of the same name") {
+            // advisory locks are one flat key-space per database, and the key is a hash of the name alone
+            val locked = mutableListOf<String>()
+            val recordingLock = object : BookmarkLock {
+                override fun tryLock(bookmark: Bookmark) = true
+                override fun tryLock(bookmarkName: String) = true.also { locked += bookmarkName }
+                override fun close() = Unit
+            }
+
+            RelationalDatabaseEntityBookmarkStore(db, store.table, recordingLock).checkoutBookmark("shared-name")
+
+            locked shouldBe listOf("entity:shared-name")
+        }
+
         it("checks out a bookmark, obtaining the lock") {
             val position = EntityPosition(baseTime, UUID.randomUUID())
             store.save("checkout-bookmark", position)

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySourceTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySourceTest.kt
@@ -3,7 +3,7 @@ package com.cultureamp.eventsourcing
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.Op
-import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -27,8 +27,12 @@ class RelationalDatabaseEntitySourceTest : DescribeSpec({
         rowToEntity = { it[goalRelationships.id] },
     )
 
-    fun insertGoalRelationship(updatedAt: LocalDateTime, deletedAt: LocalDateTime? = null): GoalRelationship {
-        val relationship = GoalRelationship(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), accountId, baseTime, updatedAt, deletedAt)
+    fun insertGoalRelationship(
+        updatedAt: LocalDateTime,
+        deletedAt: LocalDateTime? = null,
+        inAccount: UUID = accountId,
+    ): GoalRelationship {
+        val relationship = GoalRelationship(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), inAccount, baseTime, updatedAt, deletedAt)
         transaction(db) {
             goalRelationships.insert {
                 it[goalRelationships.id] = relationship.id
@@ -121,18 +125,18 @@ class RelationalDatabaseEntitySourceTest : DescribeSpec({
         }
 
         it("applies an additional filter") {
-            val live = insertGoalRelationship(baseTime.plusSeconds(1))
-            insertGoalRelationship(baseTime.plusSeconds(2), deletedAt = baseTime.plusSeconds(5))
-            val liveOnly = RelationalDatabaseEntitySource(
+            val ours = insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(2), inAccount = UUID.randomUUID())
+            val oneAccountOnly = RelationalDatabaseEntitySource(
                 db = db,
                 table = goalRelationships,
                 updatedAtColumn = goalRelationships.updatedAt,
                 idColumn = goalRelationships.id,
-                filter = { goalRelationships.deletedAt.isNull() },
+                filter = { goalRelationships.accountId eq accountId },
                 rowToEntity = { it[goalRelationships.id] },
             )
 
-            liveOnly.getAfter(null, distantFuture).map { it.entity } shouldBe listOf(live.id)
+            oneAccountOnly.getAfter(null, distantFuture).map { it.entity } shouldBe listOf(ours.id)
         }
     }
 
@@ -151,22 +155,22 @@ class RelationalDatabaseEntitySourceTest : DescribeSpec({
 
         it("respects the filter when finding the newest row") {
             insertGoalRelationship(baseTime.plusSeconds(1))
-            insertGoalRelationship(baseTime.plusSeconds(30), deletedAt = baseTime.plusSeconds(40))
-            val liveOnly = RelationalDatabaseEntitySource(
+            insertGoalRelationship(baseTime.plusSeconds(30), inAccount = UUID.randomUUID())
+            val oneAccountOnly = RelationalDatabaseEntitySource(
                 db = db,
                 table = goalRelationships,
                 updatedAtColumn = goalRelationships.updatedAt,
                 idColumn = goalRelationships.id,
-                filter = { goalRelationships.deletedAt.isNull() },
+                filter = { goalRelationships.accountId eq accountId },
                 rowToEntity = { it[goalRelationships.id] },
             )
 
-            liveOnly.lastUpdatedAt() shouldBe baseTime.plusSeconds(1)
+            oneAccountOnly.lastUpdatedAt() shouldBe baseTime.plusSeconds(1)
         }
     }
 
     describe("Op.TRUE default filter") {
-        it("reads everything by default") {
+        it("reads soft-deleted rows too, which is how a deletion reaches a projection at all") {
             val live = insertGoalRelationship(baseTime.plusSeconds(1))
             val deleted = insertGoalRelationship(baseTime.plusSeconds(2), deletedAt = baseTime.plusSeconds(5))
             val unfiltered = RelationalDatabaseEntitySource(

--- a/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySourceTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/RelationalDatabaseEntitySourceTest.kt
@@ -1,0 +1,219 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+class RelationalDatabaseEntitySourceTest : DescribeSpec({
+    val db = PgTestConfig.db ?: Database.connect(url = "jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;", driver = "org.h2.Driver")
+    val goalRelationships = GoalRelationshipsTable()
+    val baseTime = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+    val distantFuture = baseTime.plus(Duration.ofDays(365))
+    val accountId = UUID.randomUUID()
+
+    val entitySource = RelationalDatabaseEntitySource(
+        db = db,
+        table = goalRelationships,
+        updatedAtColumn = goalRelationships.updatedAt,
+        idColumn = goalRelationships.id,
+        rowToEntity = { it[goalRelationships.id] },
+    )
+
+    fun insertGoalRelationship(updatedAt: LocalDateTime, deletedAt: LocalDateTime? = null): GoalRelationship {
+        val relationship = GoalRelationship(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(), accountId, baseTime, updatedAt, deletedAt)
+        transaction(db) {
+            goalRelationships.insert {
+                it[goalRelationships.id] = relationship.id
+                it[goalRelationships.childGoalId] = relationship.childGoalId
+                it[goalRelationships.parentGoalId] = relationship.parentGoalId
+                it[goalRelationships.accountId] = relationship.accountId
+                it[goalRelationships.createdAt] = relationship.createdAt
+                it[goalRelationships.updatedAt] = relationship.updatedAt
+                it[goalRelationships.deletedAt] = relationship.deletedAt
+                it[goalRelationships.cascadingWeight] = relationship.cascadingWeight
+            }
+        }
+        return relationship
+    }
+
+    beforeTest {
+        transaction(db) {
+            SchemaUtils.create(goalRelationships)
+        }
+    }
+
+    afterTest {
+        transaction(db) {
+            SchemaUtils.drop(goalRelationships)
+        }
+    }
+
+    describe("getAfter") {
+        it("returns rows in updated-at order from the beginning when there is no position") {
+            val third = insertGoalRelationship(baseTime.plusSeconds(3))
+            val first = insertGoalRelationship(baseTime.plusSeconds(1))
+            val second = insertGoalRelationship(baseTime.plusSeconds(2))
+
+            entitySource.getAfter(null, distantFuture).map { it.entity } shouldBe listOf(first.id, second.id, third.id)
+        }
+
+        it("returns only rows strictly after the given position") {
+            insertGoalRelationship(baseTime.plusSeconds(1))
+            val second = insertGoalRelationship(baseTime.plusSeconds(2))
+            val third = insertGoalRelationship(baseTime.plusSeconds(3))
+
+            entitySource.getAfter(second.position, distantFuture).map { it.entity } shouldBe listOf(third.id)
+        }
+
+        it("positions each row by its own updated-at and id") {
+            val only = insertGoalRelationship(baseTime.plusSeconds(1))
+
+            val read = entitySource.getAfter(null, distantFuture).single()
+
+            read.position.id shouldBe only.id
+            read.position.updatedAt shouldBe only.updatedAt
+        }
+
+        it("excludes rows at or after the safe boundary") {
+            val old = insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(30))
+
+            entitySource.getAfter(null, baseTime.plusSeconds(10)).map { it.entity } shouldBe listOf(old.id)
+        }
+
+        it("excludes a row sitting exactly on the safe boundary") {
+            val onTheBoundary = insertGoalRelationship(baseTime.plusSeconds(10))
+
+            // every row of the oldest open transaction sits on exactly this value, so `<=` would admit all of them
+            entitySource.getAfter(null, onTheBoundary.updatedAt).map { it.entity } shouldBe emptyList()
+            entitySource.getAfter(null, onTheBoundary.updatedAt.plusNanos(1_000)).map { it.entity } shouldBe listOf(onTheBoundary.id)
+        }
+
+        it("returns at most batchSize rows") {
+            val inserted = (1..5).map { insertGoalRelationship(baseTime.plusSeconds(it.toLong())) }
+
+            entitySource.getAfter(null, distantFuture, batchSize = 2).map { it.entity } shouldBe inserted.take(2).map { it.id }
+        }
+
+        it("uses the id as a tiebreaker so rows sharing an updated-at are each returned exactly once") {
+            val sharedTimestamp = baseTime.plusSeconds(1)
+            val inserted = (1..5).map { insertGoalRelationship(sharedTimestamp) }
+
+            val seen = mutableListOf<UUID>()
+            var position: EntityPosition? = null
+            while (true) {
+                val batch = entitySource.getAfter(position, distantFuture, batchSize = 2)
+                if (batch.isEmpty()) break
+                seen += batch.map { it.entity }
+                position = batch.last().position
+            }
+
+            seen.size shouldBe 5
+            seen.toSet() shouldBe inserted.map { it.id }.toSet()
+        }
+
+        it("applies an additional filter") {
+            val live = insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(2), deletedAt = baseTime.plusSeconds(5))
+            val liveOnly = RelationalDatabaseEntitySource(
+                db = db,
+                table = goalRelationships,
+                updatedAtColumn = goalRelationships.updatedAt,
+                idColumn = goalRelationships.id,
+                filter = { goalRelationships.deletedAt.isNull() },
+                rowToEntity = { it[goalRelationships.id] },
+            )
+
+            liveOnly.getAfter(null, distantFuture).map { it.entity } shouldBe listOf(live.id)
+        }
+    }
+
+    describe("lastUpdatedAt") {
+        it("returns null when the table is empty") {
+            entitySource.lastUpdatedAt() shouldBe null
+        }
+
+        it("returns the newest updated-at in the table") {
+            insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(30))
+            insertGoalRelationship(baseTime.plusSeconds(2))
+
+            entitySource.lastUpdatedAt() shouldBe baseTime.plusSeconds(30)
+        }
+
+        it("respects the filter when finding the newest row") {
+            insertGoalRelationship(baseTime.plusSeconds(1))
+            insertGoalRelationship(baseTime.plusSeconds(30), deletedAt = baseTime.plusSeconds(40))
+            val liveOnly = RelationalDatabaseEntitySource(
+                db = db,
+                table = goalRelationships,
+                updatedAtColumn = goalRelationships.updatedAt,
+                idColumn = goalRelationships.id,
+                filter = { goalRelationships.deletedAt.isNull() },
+                rowToEntity = { it[goalRelationships.id] },
+            )
+
+            liveOnly.lastUpdatedAt() shouldBe baseTime.plusSeconds(1)
+        }
+    }
+
+    describe("Op.TRUE default filter") {
+        it("reads everything by default") {
+            val live = insertGoalRelationship(baseTime.plusSeconds(1))
+            val deleted = insertGoalRelationship(baseTime.plusSeconds(2), deletedAt = baseTime.plusSeconds(5))
+            val unfiltered = RelationalDatabaseEntitySource(
+                db = db,
+                table = goalRelationships,
+                updatedAtColumn = goalRelationships.updatedAt,
+                idColumn = goalRelationships.id,
+                filter = { Op.TRUE },
+                rowToEntity = { it[goalRelationships.id] },
+            )
+
+            unfiltered.getAfter(null, distantFuture).map { it.entity } shouldBe listOf(live.id, deleted.id)
+        }
+    }
+
+    describe("mapping whole rows") {
+        it("maps every column of the real table") {
+            val inserted = insertGoalRelationship(baseTime.plusSeconds(1), deletedAt = baseTime.plusSeconds(2))
+            val wholeRows = RelationalDatabaseEntitySource(
+                db = db,
+                table = goalRelationships,
+                updatedAtColumn = goalRelationships.updatedAt,
+                idColumn = goalRelationships.id,
+                rowToEntity = {
+                    GoalRelationship(
+                        id = it[goalRelationships.id],
+                        childGoalId = it[goalRelationships.childGoalId],
+                        parentGoalId = it[goalRelationships.parentGoalId],
+                        accountId = it[goalRelationships.accountId],
+                        createdAt = it[goalRelationships.createdAt],
+                        updatedAt = it[goalRelationships.updatedAt],
+                        deletedAt = it[goalRelationships.deletedAt],
+                        cascadingWeight = it[goalRelationships.cascadingWeight],
+                    )
+                },
+            )
+
+            val read = wholeRows.getAfter(null, distantFuture).single().entity
+
+            read.id shouldBe inserted.id
+            read.childGoalId shouldBe inserted.childGoalId
+            read.parentGoalId shouldBe inserted.parentGoalId
+            read.accountId shouldBe inserted.accountId
+            read.createdAt shouldBe inserted.createdAt
+            read.updatedAt shouldBe inserted.updatedAt
+            read.deletedAt shouldBe inserted.deletedAt
+            read.cascadingWeight.compareTo(inserted.cascadingWeight) shouldBe 0
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
@@ -1,0 +1,63 @@
+package com.cultureamp.eventsourcing
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.time.Duration
+import java.time.LocalDateTime
+
+/**
+ * The parts of the boundary that need no database. The refusals are checked here rather than in
+ * [PostgresXactStartSafeBoundaryTest] because provoking them for real needs a server-level setting
+ * (`max_prepared_transactions`) or an unprivileged role, and because they have to hold on any Postgres, not just one
+ * that can be configured to demonstrate them.
+ */
+class SafeBoundaryTest : DescribeSpec({
+    val boundary = LocalDateTime.of(2026, 8, 10, 9, 0, 0, 0)
+
+    describe("Observation.validated") {
+        it("returns the boundary when nothing is hidden and no prepared transactions are configured") {
+            PostgresXactStartSafeBoundary.Observation(boundary, redactedBackends = 0, maxPreparedTransactions = 0)
+                .validated() shouldBe boundary
+        }
+
+        it("refuses to report a boundary when prepared transactions are enabled") {
+            // a prepared transaction is not an ordinary backend, so pg_stat_activity cannot show it to min(xact_start)
+            val exception = shouldThrow<SafeBoundaryUnsupportedException> {
+                PostgresXactStartSafeBoundary.Observation(boundary, redactedBackends = 0, maxPreparedTransactions = 10)
+                    .validated()
+            }
+
+            exception.message!! shouldContain "max_prepared_transactions is 10"
+        }
+
+        it("refuses to report a boundary when backends are hidden from the reader") {
+            val exception = shouldThrow<SafeBoundaryUnreliableException> {
+                PostgresXactStartSafeBoundary.Observation(boundary, redactedBackends = 2, maxPreparedTransactions = 0)
+                    .validated()
+            }
+
+            exception.message!! shouldContain "2 backend(s)"
+        }
+
+        it("reports the prepared-transaction problem first, since it cannot be fixed by a grant") {
+            shouldThrow<SafeBoundaryUnsupportedException> {
+                PostgresXactStartSafeBoundary.Observation(boundary, redactedBackends = 2, maxPreparedTransactions = 10)
+                    .validated()
+            }
+        }
+    }
+
+    describe("unsafeFixedDelay") {
+        it("holds back by the delay") {
+            val now = boundary.plusSeconds(30)
+
+            SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)) { now }.safeBefore() shouldBe now.minusSeconds(10)
+        }
+
+        it("has no blocker diagnosis to offer") {
+            SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)).describeBlockers() shouldContain "no blocker diagnosis"
+        }
+    }
+})

--- a/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
@@ -4,7 +4,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import java.time.Duration
 import java.time.LocalDateTime
 
 /**
@@ -49,18 +48,9 @@ class SafeBoundaryTest : DescribeSpec({
         }
     }
 
-    describe("unsafeFixedDelay") {
-        it("holds back by the delay") {
-            val now = boundary.plusSeconds(30)
-
-            val reading = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)) { now }.read()
-
-            reading.safeBefore shouldBe now.minusSeconds(10)
-            reading.readAt shouldBe now
-        }
-
-        it("has no blocker diagnosis to offer") {
-            SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)).describeBlockers() shouldContain "no blocker diagnosis"
+    describe("describeBlockers") {
+        it("says it has no diagnosis to offer, rather than implying nothing is blocking") {
+            SafeBoundary { SafeBoundaryReading(boundary, boundary) }.describeBlockers() shouldContain "no blocker diagnosis"
         }
     }
 })

--- a/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
+++ b/src/test/kotlin/com/cultureamp/eventsourcing/SafeBoundaryTest.kt
@@ -19,7 +19,7 @@ class SafeBoundaryTest : DescribeSpec({
     describe("Observation.validated") {
         it("returns the boundary when nothing is hidden and no prepared transactions are configured") {
             PostgresXactStartSafeBoundary.Observation(boundary, redactedBackends = 0, maxPreparedTransactions = 0)
-                .validated() shouldBe boundary
+                .validated() shouldBe SafeBoundaryReading(boundary, boundary)
         }
 
         it("refuses to report a boundary when prepared transactions are enabled") {
@@ -53,7 +53,10 @@ class SafeBoundaryTest : DescribeSpec({
         it("holds back by the delay") {
             val now = boundary.plusSeconds(30)
 
-            SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)) { now }.safeBefore() shouldBe now.minusSeconds(10)
+            val reading = SafeBoundary.unsafeFixedDelay(Duration.ofSeconds(10)) { now }.read()
+
+            reading.safeBefore shouldBe now.minusSeconds(10)
+            reading.readAt shouldBe now
         }
 
         it("has no blocker diagnosis to offer") {


### PR DESCRIPTION
Replaces #80, which carried temporary publishing scaffolding that must never reach `master` or a public artifact. Rather than rebasing that branch and dropping the two "branch only" commits, this is a fresh branch off current `master` with the same work in two commits and no scaffolding in its history at all — so the merged diff can be read rather than trusted. Close #80 in favour of this.

TGI-199. Reference-only PoC: #80 (branch `wb/entity-processors`, head `9521364`).

## What it adds

The event-processor stack, mirrored for the case where the thing you want to project from is rows in a table owned by someone else. Rows are read in `(updated_at, id)` order, the same as the Confluent JDBC source connector's "timestamp+incrementing" mode. `EntitySource`, `EntityProcessor`, `EntityBookmarkStore`, `BatchedAsyncEntityProcessor`, `AsyncEntityProcessorMonitor` and `EntityUpdatedAtStats` each correspond to an event-sourcing piece; the README has the table.

Nothing existing changes behaviour. `BookmarkLock` gains a `tryLock(bookmarkName: String)` overload with a default implementation delegating to the existing one, so no existing implementation has to change.

## Positions are naive timestamps holding UTC

Changed from the PoC, which carried positions as `Instant` and required the polled column to be `timestamp with time zone`.

An `EntityPosition` now carries a `java.time.LocalDateTime`, read straight out of a `timestamp without time zone` column and carried around unconverted — the convention the events table already uses for its own `created_at`, and the shape of the column a consumer actually has.

Nothing in the library converts between zones, so the one thing a consumer has to get right is that the column is stamped in UTC: a column stamped in local time would be compared against a boundary read in UTC, and the hold-back would be wrong by the offset. What the library can do is agree with itself, and it does:

- every `clock` default reads `LocalDateTime.now(ZoneOffset.UTC)`, not `LocalDateTime::now`
- `PostgresXactStartSafeBoundary` converts with an explicit `AT TIME ZONE 'UTC'` rather than leaning on the session's `TimeZone`, which is connection-pool configuration a reader has no control over
- the README says to stamp the column `GREATEST(clock_timestamp(), transaction_timestamp()) AT TIME ZONE 'UTC'`

Being nanosecond-precision, a `LocalDateTime` round-trips a `timestamp` exactly, so a bookmark saved from a row selects strictly past that row next time and the column has no precision requirement.

## Reading by `updated_at` needs a safe boundary, not a fixed delay

Most of `SafeBoundary.kt`. An `updated_at` column does not record commit order: Postgres `now()` is fixed when a transaction *starts*, so a transaction beginning at 12:00 and committing at 12:30 makes rows visible half an hour after the timestamp they carry, and a reader whose bookmark has meanwhile passed 12:00 — which ordinary concurrent traffic will do for it — never sees those rows again. Nothing errors and nothing stalls.

A hold-back of "now minus a delay" only makes that unlikely, and only while every writing transaction commits inside the delay. `PostgresXactStartSafeBoundary` closes it instead, with no WAL, LSN, replication slot or CDC connector: `min(xact_start)` from `pg_stat_activity`, capped at `statement_timestamp()`, so the reader never passes the start of the oldest transaction that could still commit. Both sides of that comparison are database-generated, so clock skew between application and database cannot affect correctness. `safeBefore` is exclusive because every row of the oldest open transaction sits at exactly its `xact_start`, which is exactly the boundary.

Its cost is a liveness one — it cannot tell a transaction that will write this table from one that never will — so `BatchedAsyncEntityProcessor` throws `SafeBoundaryStalledException` once it has been held back for `stallThreshold` (an hour by default), naming the pid, `application_name` and age of the oldest open transactions. Not their query text: for a session idle in transaction that is the last statement it ran, which on a write path carries row values. Reading nothing is only a stall when the head of the table sits at or beyond the boundary — a backfill reading happily behind an old boundary is not one.

## Version: 0.32.0, not 0.35.0

TGI-199 asks for `base_version=0.35.0` retained. That was the right number for a rebase of #80, whose history walked 0.31.0 → 0.35.0 as the design changed under review. None of 0.32.0–0.35.0 was ever released; `master` has meanwhile released 0.31.0 for something else. So this lands as one release of one feature and the next number is 0.32.0, with a single CHANGELOG entry describing the end state rather than five describing how it got there.

## Cleanliness, since that is the point of this PR

- `build.gradle` has one publishing repository, the existing Sonatype/Central one. No `GitHubPackages` block.
- `version_suffix` is empty.
- No occurrence of `tgi97`, `wip` or `publish-kestrel` anywhere in the tree or in either commit.

## Testing

49 entity tests and 11 `PostgresXactStartSafeBoundary` tests, green against both H2 and a real Postgres 14. The boundary spec needs a real Postgres (`pg_stat_activity` has no H2 equivalent) and takes one from testcontainers by default, or from `KESTREL_TEST_PG_URL` where Docker is unavailable.

Full suite locally: 14 failures, all the pre-existing testcontainers ones — `master` reports 11 of the same, and the extra three are Kotest 4.6.2 attributing one spec's container-launch error to other specs, whose own cases all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

